### PR TITLE
[GoCD Helm Chart] Bump up GoCD Version to 20.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+### 1.31.0
+* [44d55ea](https://github.com/kubernetes/charts/commit/44d55ea): Bump up GoCD Version to 20.8.0
 ### 1.30.3
 * [3b9e171](https://github.com/gocd/helm-chart/commit/3b9e171): Move GoCD Helm Chart readme to gocd repository
 ### 1.30.2

--- a/gocd/Chart.yaml
+++ b/gocd/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: gocd
 home: https://www.gocd.org/
-version: 1.30.3
-appVersion: 20.7.0
+version: 1.31.0
+appVersion: 20.8.0
 description: GoCD is an open-source continuous delivery server to model and visualize complex workflows with ease.
 icon: https://gocd.github.io/assets/images/go-icon-black-192x192.png
 keywords:


### PR DESCRIPTION
Bump up GoCD Version to 20.8.0 