### PR TITLE
Add extra paths config

### DIFF
--- a/gocd/Chart.yaml
+++ b/gocd/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: gocd
 home: https://www.gocd.org/
-version: 1.32.0
+version: 1.33.0
 appVersion: 20.9.0
 description: GoCD is an open-source continuous delivery server to model and visualize complex workflows with ease.
 icon: https://gocd.github.io/assets/images/go-icon-black-192x192.png

--- a/gocd/README.md
+++ b/gocd/README.md
@@ -96,6 +96,8 @@ The following tables list the configurable parameters of the GoCD chart and thei
 | `server.ingress.enabled`                   | Enable/disable GoCD ingress. Allow traffic from outside the cluster via http. Do `kubectl describe ing` to get the public ip to access the gocd server.                                | `true`              |
 | `server.ingress.hosts`                     | GoCD ingress hosts records.                                                                                   | `nil`               |
 | `server.ingress.annotations`               | GoCD ingress annotations.                                                                                     | `{}`                |
+| `server.ingress.path`                      | GoCD ingress path.                                                                                            | `/`                |
+| `server.ingress.extraPaths`                | GoCD ingress extra paths to prepend to every host configuration.                                              | `[]`                |
 | `server.ingress.tls`                       | GoCD ingress TLS configuration.                                                                               | `[]`                |
 | `server.healthCheck.initialDelaySeconds`   | Initial delays in seconds to start the health checks. **Note**:GoCD server start up time.                     | `90`                |
 | `server.healthCheck.periodSeconds`         | GoCD server health check interval period.                                                                      | `15`                |

--- a/gocd/templates/ingress.yaml
+++ b/gocd/templates/ingress.yaml
@@ -1,5 +1,7 @@
 {{- if .Values.server.enabled }}
 {{- if .Values.server.ingress.enabled -}}
+{{- $ingressPath := .Values.server.ingress.path -}}
+{{- $extraPaths := .Values.server.ingress.extraPaths -}}
 apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
@@ -22,9 +24,13 @@ spec:
     - host: {{ $host | quote }}
       http:
         paths:
-        - backend:
-            serviceName: {{ template "gocd.fullname" $dot }}-server
-            servicePort: {{ $dot.Values.server.service.httpPort }}
+        {{ if $extraPaths }}
+{{ toYaml $extraPaths | indent 10 }}
+        {{- end }}
+          - path: {{ $ingressPath }}
+            backend:
+              serviceName: {{ template "gocd.fullname" $dot }}-server
+              servicePort: {{ $dot.Values.server.service.httpPort }}
     {{- end }}
   {{- else }}
   backend:

--- a/gocd/values.yaml
+++ b/gocd/values.yaml
@@ -154,6 +154,12 @@ server:
     annotations:
       # kubernetes.io/ingress.class: nginx
       # kubernetes.io/tls-acme: "true"
+    path: /
+    extraPaths: []
+    # - path: /*
+    #   backend:
+    #     serviceName: ssl-redirect
+    #     servicePort: use-annotation
     tls:
     #  - secretName: ci-example-tls
     #    hosts:


### PR DESCRIPTION
This PR adds the ability to specify ingress paths and extra paths for each host.

This is required to add SSL redirection when using [aws-load-balancer-controller](https://github.com/kubernetes-sigs/aws-load-balancer-controller).

See the [SSL redirection docs](https://kubernetes-sigs.github.io/aws-load-balancer-controller/guide/tasks/ssl_redirect/). Both the existing base path must be set to /*, and an extra ssl-redirect path must be prepended.  

The logic added is in the same style as I have seen with other charts, such as [grafana](https://github.com/grafana/helm-charts/blob/main/charts/grafana/templates/ingress.yaml#L40).

Thanks!