### PR TITLE
[GoCD Helm Chart] Bump up GoCD Version to 20.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+### 1.34.0
+* [6d5a7f6](https://github.com/kubernetes/charts/commit/6d5a7f6): Bump up GoCD Version to 20.10.0
 ### 1.32.0
 * [c656595](https://github.com/kubernetes/charts/commit/c656595): Bump up GoCD Version to 20.9.0
 ### 1.31.0

--- a/gocd/Chart.yaml
+++ b/gocd/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: gocd
 home: https://www.gocd.org/
-version: 1.33.0
-appVersion: 20.9.0
+version: 1.34.0
+appVersion: 20.10.0
 description: GoCD is an open-source continuous delivery server to model and visualize complex workflows with ease.
 icon: https://gocd.github.io/assets/images/go-icon-black-192x192.png
 keywords:


### PR DESCRIPTION
PR to update the helm chart to the latest version of GoCD