### PR TITLE
[GoCD Helm Chart] Bump up GoCD Version to 21.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+### 1.35.0
+* [b4d695c](https://github.com/kubernetes/charts/commit/b4d695c): Bump up GoCD Version to 21.1.0
 ### 1.34.0
 * [6d5a7f6](https://github.com/kubernetes/charts/commit/6d5a7f6): Bump up GoCD Version to 20.10.0
 ### 1.32.0

--- a/gocd/Chart.yaml
+++ b/gocd/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: gocd
 home: https://www.gocd.org/
-version: 1.34.0
-appVersion: 20.10.0
+version: 1.35.0
+appVersion: 21.1.0
 description: GoCD is an open-source continuous delivery server to model and visualize complex workflows with ease.
 icon: https://gocd.github.io/assets/images/go-icon-black-192x192.png
 keywords:


### PR DESCRIPTION
PR to update the helm chart to the latest version of GoCD