### PR TITLE
[GoCD Helm Chart] Bump up GoCD Version to 21.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+### 1.37.0
+* [5e413e6](https://github.com/kubernetes/charts/commit/5e413e6): Bump up GoCD Version to 21.2.0
 ### 1.36.0
 * [8635e14](https://github.com/gocd/helm-chart/commit/8635e14): Update the gocd agent image used
 ### 1.35.0

--- a/gocd/Chart.yaml
+++ b/gocd/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: gocd
 home: https://www.gocd.org/
-version: 1.36.0
-appVersion: 21.1.0
+version: 1.37.0
+appVersion: 21.2.0
 description: GoCD is an open-source continuous delivery server to model and visualize complex workflows with ease.
 icon: https://gocd.github.io/assets/images/go-icon-black-192x192.png
 keywords:


### PR DESCRIPTION
PR to update the helm chart to the latest version of GoCD