### PR TITLE
Add custom labels to Server and Agent

### DIFF
--- a/gocd/templates/gocd-agent-deployment.yaml
+++ b/gocd/templates/gocd-agent-deployment.yaml
@@ -8,6 +8,9 @@ metadata:
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
     component: agent
+    {{- with .Values.agent.labels }}
+{{ toYaml . | indent 4 }}
+    {{- end }}
   annotations:
   {{- range $key, $value := .Values.agent.annotations.deployment }}
     {{ $key }}: {{ $value | quote }}

--- a/gocd/templates/gocd-agent-deployment.yaml
+++ b/gocd/templates/gocd-agent-deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
     component: agent
-    {{- with .Values.agent.labels }}
+    {{- with .Values.agent.deployment.labels }}
 {{ toYaml . | indent 4 }}
     {{- end }}
   annotations:
@@ -32,6 +32,9 @@ spec:
         app: {{ template "gocd.name" . }}
         release: {{ .Release.Name | quote }}
         component: agent
+        {{- with .Values.agent.pod.labels }}
+{{ toYaml . | indent 8 }}
+        {{- end }}
       annotations:
       {{- range $key, $value := .Values.agent.annotations.pod }}
         {{ $key }}: {{ $value | quote }}

--- a/gocd/templates/gocd-server-deployment.yaml
+++ b/gocd/templates/gocd-server-deployment.yaml
@@ -9,7 +9,7 @@ metadata:
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
     component: server
-    {{- with .Values.server.labels }}
+    {{- with .Values.server.deployment.labels }}
 {{ toYaml . | indent 4 }}
     {{- end }}
   annotations:
@@ -31,6 +31,9 @@ spec:
         app: {{ template "gocd.name" . }}
         release: {{ .Release.Name | quote }}
         component: server
+        {{- with .Values.server.pod.labels }}
+{{ toYaml . | indent 8 }}
+        {{- end }}
       annotations:
       {{- range $key, $value := .Values.server.annotations.pod }}
         {{ $key }}: {{ $value | quote }}

--- a/gocd/templates/gocd-server-deployment.yaml
+++ b/gocd/templates/gocd-server-deployment.yaml
@@ -9,6 +9,9 @@ metadata:
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
     component: server
+    {{- with .Values.server.labels }}
+{{ toYaml . | indent 4 }}
+    {{- end }}
   annotations:
   {{- range $key, $value := .Values.server.annotations.deployment }}
     {{ $key }}: {{ $value | quote }}

--- a/gocd/values.yaml
+++ b/gocd/values.yaml
@@ -22,8 +22,12 @@ server:
   # server.enabled is the toggle to run GoCD Server. Change to false for Agent Only Deployment.
   enabled: true
 
-  # server.labels is the labels for the GoCD Server Deployment
-  labels: {}
+  # server.deployment.labels is the labels for the GoCD Server Deployment
+  deployment:
+    labels: {}
+  # server.pod.labels is the labels for the GoCD Server Pods
+  pod:
+    labels: {}
   # server.annotations is the annotations for the GoCD Server Deployment and Pod spec.
   annotations:
     deployment:
@@ -241,8 +245,13 @@ agent:
     # If field is empty, the service account "default" will be used.
     name:
 
-  # agent.labels is the labels for the GoCD Agent Deployment
-  labels: {}
+  # agent.deployment.labels is the labels for the GoCD Agent Deployment
+  deployment:
+    labels: {}
+  # agent.pod.labels is the labels for the GoCD Agent Pods
+  pod:
+    labels: {}
+  
   # agent.annotations is the annotations for the GoCD Agent Deployment and Pod Spec
   annotations:
     deployment:

--- a/gocd/values.yaml
+++ b/gocd/values.yaml
@@ -22,7 +22,8 @@ server:
   # server.enabled is the toggle to run GoCD Server. Change to false for Agent Only Deployment.
   enabled: true
 
-
+  # server.labels is the labels for the GoCD Server Deployment
+  labels: {}
   # server.annotations is the annotations for the GoCD Server Deployment and Pod spec.
   annotations:
     deployment:
@@ -240,6 +241,8 @@ agent:
     # If field is empty, the service account "default" will be used.
     name:
 
+  # agent.labels is the labels for the GoCD Agent Deployment
+  labels: {}
   # agent.annotations is the annotations for the GoCD Agent Deployment and Pod Spec
   annotations:
     deployment:

--- a/gocd/values.yaml
+++ b/gocd/values.yaml
@@ -251,7 +251,7 @@ agent:
   # agent.pod.labels is the labels for the GoCD Agent Pods
   pod:
     labels: {}
-  
+
   # agent.annotations is the annotations for the GoCD Agent Deployment and Pod Spec
   annotations:
     deployment:


### PR DESCRIPTION
Added additional values to allow for custom labels for the server and agents.
Users have the ability to add pod specific and deployment specific labels.