### PR TITLE
Correct compatibility of Ingress for Kubernetes 1.22

### DIFF
--- a/.github/ct.yaml
+++ b/.github/ct.yaml
@@ -1,6 +1,6 @@
 chart-dirs: .
 charts:
   - gocd
-helm-extra-args: --timeout 1800s
+helm-extra-args: --timeout 300s
 check-version-increment: true
 debug: true

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -1,6 +1,12 @@
 name: Lint and Test Charts
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 
 jobs:
   lint-test:

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -5,6 +5,13 @@ on: [push, pull_request]
 jobs:
   lint-test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        k8s:
+          - v1.19.11
+          - v1.20.7
+          - v1.21.2
+          - v1.22.2
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -36,6 +43,8 @@ jobs:
 
       - name: Create kind cluster
         uses: helm/kind-action@v1.2.0
+        with:
+          node_image: kindest/node:${{ matrix.k8s }}
         # Only build a kind cluster if there are chart changes to test.
         if: steps.list-changed.outputs.changed == 'true'
 

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -13,11 +13,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        k8s:
+        k8s: # See https://hub.docker.com/r/kindest/node/tags
           - v1.19.11
           - v1.20.7
           - v1.21.2
-          - v1.22.2
+          - v1.22.1
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,13 +1,14 @@
 name: Release Charts
 
 on:
-  push:
-    branches:
-      - master
-
+  workflow_run:
+    workflows: [Lint and Test Charts]
+    branches: [master]
+    types: [completed]
 jobs:
   release:
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+### 1.39.2
+* [c12c74c](https://github.com/gocd/helm-chart/commit/c12c74c): Correct Ingress compatibility with Kubernetes 1.22 
 ### 1.39.1
 * [e584fd9](https://github.com/gocd/helm-chart/commit/e584fd9): Bump Alpine agent image variant from 3.12 to 3.14
 ### 1.39.0

--- a/gocd/Chart.yaml
+++ b/gocd/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: gocd
 home: https://www.gocd.org/
-version: 1.39.1
+version: 1.39.2
 appVersion: 21.3.0
 description: GoCD is an open-source continuous delivery server to model and visualize complex workflows with ease.
 icon: https://gocd.github.io/assets/images/go-icon-black-192x192.png

--- a/gocd/Chart.yaml
+++ b/gocd/Chart.yaml
@@ -23,3 +23,5 @@ maintainers:
   email: ganeshpl@thoughtworks.com
 - name: varshavaradarajan
   email: varshasvaradarajan@gmail.com
+- name: chadlwilson
+  email: chadw@thoughtworks.com

--- a/gocd/OWNERS
+++ b/gocd/OWNERS
@@ -9,6 +9,7 @@ approvers:
 - marques-work
 - kritika-singh3
 - ibnc
+- chadlwilson
 reviewers:
 - arvindsv
 - bdpiparva
@@ -20,3 +21,4 @@ reviewers:
 - marques-work
 - kritika-singh3
 - ibnc
+- chadlwilson

--- a/gocd/README.md
+++ b/gocd/README.md
@@ -96,6 +96,7 @@ The following tables list the configurable parameters of the GoCD chart and thei
 | `server.ingress.hosts`                     | GoCD ingress hosts records.                                                                                   | `nil`               |
 | `server.ingress.annotations`               | GoCD ingress annotations.                                                                                     | `{}`                |
 | `server.ingress.path`                      | GoCD ingress path.                                                                                            | `/`                |
+| `server.ingress.pathType`                  | GoCD ingress path type.                                                                                       | `ImplementationSpecific` |
 | `server.ingress.extraPaths`                | GoCD ingress extra paths to prepend to every host configuration.                                              | `[]`                |
 | `server.ingress.tls`                       | GoCD ingress TLS configuration.                                                                               | `[]`                |
 | `server.healthCheck.initialDelaySeconds`   | Initial delays in seconds to start the health checks. **Note**:GoCD server start up time.                     | `90`                |

--- a/gocd/README.md
+++ b/gocd/README.md
@@ -92,7 +92,6 @@ The following tables list the configurable parameters of the GoCD chart and thei
 | `server.service.loadBalancerSourceRanges`  | GoCD server service Load Balancer source IP ranges to whitelist                                               | `nil`               |
 | `server.service.httpPort`                  | GoCD server service HTTP port                                                                                 | `8153`              |
 | `server.service.nodeHttpPort`              | GoCD server service node HTTP port. **Note**: A random nodePort will get assigned if not specified            | `nil`               |
-| `server.service.nodeHttpsPort`             | GoCD server service node HTTPS port. **Note**: A random nodePort will get assigned if not specified           | `nil`               |
 | `server.ingress.enabled`                   | Enable/disable GoCD ingress. Allow traffic from outside the cluster via http. Do `kubectl describe ing` to get the public ip to access the gocd server.                                | `true`              |
 | `server.ingress.hosts`                     | GoCD ingress hosts records.                                                                                   | `nil`               |
 | `server.ingress.annotations`               | GoCD ingress annotations.                                                                                     | `{}`                |

--- a/gocd/templates/ingress.yaml
+++ b/gocd/templates/ingress.yaml
@@ -1,8 +1,11 @@
 {{- if .Values.server.enabled }}
 {{- if .Values.server.ingress.enabled -}}
-{{- $ingressPath := .Values.server.ingress.path -}}
 {{- $extraPaths := .Values.server.ingress.extraPaths -}}
+{{- if semverCompare "<1.19-0" .Capabilities.KubeVersion.Version -}}
 apiVersion: networking.k8s.io/v1beta1
+{{- else }}
+apiVersion: networking.k8s.io/v1
+{{- end }}
 kind: Ingress
 metadata:
   name: {{ template "gocd.fullname" . }}-server
@@ -27,15 +30,33 @@ spec:
         {{ if $extraPaths }}
 {{ toYaml $extraPaths | indent 10 }}
         {{- end }}
-          - path: {{ $ingressPath }}
+          - path: {{ $.Values.server.ingress.path }}
+            {{- if semverCompare ">=1.18-0" $.Capabilities.KubeVersion.Version }}
+            pathType: {{ default "ImplementationSpecific" $.Values.server.ingress.pathType }}
+            {{- end }}
             backend:
+              {{- if semverCompare "<1.19-0" $.Capabilities.KubeVersion.Version }}
               serviceName: {{ template "gocd.fullname" $dot }}-server
               servicePort: {{ $dot.Values.server.service.httpPort }}
+              {{- else }}
+              service:
+                name: {{ template "gocd.fullname" $dot }}-server
+                port:
+                  number: {{ $dot.Values.server.service.httpPort }}
+              {{- end }}
     {{- end }}
   {{- else }}
+  {{- if semverCompare "<1.19-0" .Capabilities.KubeVersion.Version }}
   backend:
     serviceName: {{ template "gocd.fullname" . }}-server
     servicePort: {{ .Values.server.service.httpPort }}
+  {{- else }}
+  defaultBackend:
+    service:
+      name: {{ template "gocd.fullname" . }}-server
+      port:
+        number: {{ .Values.server.service.httpPort }}
+  {{- end -}}
   {{- end -}}
   {{- if .Values.server.ingress.tls }}
   tls:

--- a/gocd/values.yaml
+++ b/gocd/values.yaml
@@ -158,6 +158,7 @@ server:
       # kubernetes.io/ingress.class: nginx
       # kubernetes.io/tls-acme: "true"
     path: /
+    pathType:
     extraPaths: []
     # - path: /*
     #   backend:

--- a/gocd/values.yaml
+++ b/gocd/values.yaml
@@ -135,11 +135,9 @@ server:
     type: "NodePort"
     # server.service.httpPort is the GoCD Server HTTP port
     httpPort: 8153
-    # Provide the nodeHttpPort and nodeHttpsPort if you want the service to be exposed on specific ports. Without this, random node ports will be assigned.
+    # Provide the nodeHttpPort if you want the service to be exposed on specific ports. Without this, random node ports will be assigned.
     # server.service.nodeHttpPort is the GoCD Server Service Node HTTP port
     nodeHttpPort:
-    # server.service.nodeHttpPort is the GoCD Server Service Node HTTPS port
-    nodeHttpsPort:
     annotations:
       ## When using LoadBalancer service type, use the following AWS certificate from ACM
       ## https://aws.amazon.com/documentation/acm/


### PR DESCRIPTION
Fixes #16. 

- `networking.k8s.io/v1beta1` of `Ingress` is gone in `1.22`.
- `networking.k8s.io/v1` has been available since `1.19` but involves some changes as documented [here](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#ingress-v122)
- Additionally `pathType` is now mandatory, however only [supported since Kubernetes 1.18](https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/#better-path-matching-with-path-types).

These changes should be backward compatible, and mirror the way the new API serves up data created via the old API version.

Additionally
- removed redundant `nodeHttpsPort` which is no longer used by the chart
- added myself as maintainer
- Changed lint+test to run across multiple k8s versiobs
- Fixed test workflow to run only once on PRs, and release to only happen on master after tests complete

Tested
- [X] Fresh install on 1.22 with ingress (default backend and specific hosts)
- [X] Fresh install of *old chart* on 1.21 with Ingress, then upgrading to new chart
- [X] Fresh install on 1.19 with ingress (default backend and specific hosts)