### PR TITLE
Add ability to set server priorityClassName

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+### 1.39.3
+* [b778db9](https://github.com/gocd/helm-chart/commit/b778db9): Add ability to set server priorityClassName
 ### 1.39.2
 * [c12c74c](https://github.com/gocd/helm-chart/commit/c12c74c): Correct Ingress compatibility with Kubernetes 1.22 
 ### 1.39.1

--- a/gocd/Chart.yaml
+++ b/gocd/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: gocd
 home: https://www.gocd.org/
-version: 1.39.2
+version: 1.39.3
 appVersion: 21.3.0
 description: GoCD is an open-source continuous delivery server to model and visualize complex workflows with ease.
 icon: https://gocd.github.io/assets/images/go-icon-black-192x192.png

--- a/gocd/README.md
+++ b/gocd/README.md
@@ -82,6 +82,7 @@ The following tables list the configurable parameters of the GoCD chart and thei
 | `server.image.pullPolicy`                  | Image pull policy                                                                                             | `IfNotPresent`      |
 | `server.resources`                         | GoCD server resource requests and limits                                                                      | `{}`                |
 | `server.initContainers`                    | GoCD server init containers                                                                                   | `[]`                |
+| `server.priorityClassName`                 | GoCD server priority class                                                                                    | `nil`               |
 | `server.restartPolicy`                     | GoCD server restart policy                                                                                    | `Always`            |
 | `server.nodeSelector`                      | GoCD server nodeSelector for pod labels                                                                       | `{}`                |
 | `server.affinity`                          | GoCD server affinity                                                                                          | `{}`                |
@@ -373,7 +374,7 @@ The RBAC section is for users who want to use the Kubernetes Elastic Agent Plugi
 If RBAC is enabled,
  1. A cluster role is created by default and the following privileges are provided.
 
-    <a name="cluster-role-privileges"></a>Cluser role privileges:
+    Cluster role privileges:
       - nodes: list, get
       - events: list, watch
       - namespace: list, get
@@ -427,7 +428,7 @@ Possible states:
 |------|--------------------------------------------------|
 |reuseTopLevelServiceAccount = false and name = empty|The service account 'default' will be used.|
 |reuseTopLevelServiceAccount = false and name = 'agentSA'|The 'agentSA' service account will be used. The service account needs to exist and bound with the appropriate role. |
-|reuseTopLevelServiceAccount = true| The GoCD service account will be created and used for the agents in the specified namespace. The permissions associated with the GoCD SA are defined here - [Cluster role privileges](#cluster-role-privileges).  |
+|reuseTopLevelServiceAccount = true| The GoCD service account will be created and used for the agents in the specified namespace. The permissions associated with the GoCD SA are defined above.  |
 
 # Adding plugins
 

--- a/gocd/templates/gocd-server-deployment.yaml
+++ b/gocd/templates/gocd-server-deployment.yaml
@@ -152,6 +152,9 @@ spec:
       {{- if .Values.server.terminationGracePeriodSeconds }}
       terminationGracePeriodSeconds: {{ .Values.server.terminationGracePeriodSeconds }}
       {{- end }}
+      {{- if .Values.server.priorityClassName }}
+      priorityClassName: {{ .Values.server.priorityClassName }}
+      {{- end }}
       restartPolicy: {{ .Values.server.restartPolicy }}
     {{- if .Values.server.nodeSelector }}
       nodeSelector:

--- a/gocd/values.yaml
+++ b/gocd/values.yaml
@@ -56,6 +56,8 @@ server:
   # server.terminationGracePeriodSeconds is the optional duration in seconds the gocd server pod needs to terminate gracefully.
   # Note: SIGTERM is issued immediately after the pod deletion request is sent. If the pod doesn't terminate, k8s waits for terminationGracePeriodSeconds before issuing SIGKILL.
   # terminationGracePeriodSeconds: 60
+  # server.priorityClassName is an optional setting to allow the server pod to be prioritized over other pods. The value here must match a priotyClass that exists on the cluster
+  # priorityClassName: high-priority
   image:
     # server.image.repository is the GoCD Server image name
     repository: "gocd/gocd-server"


### PR DESCRIPTION
This should result in no changes to the chart output unless the priorityClassName is set in values.yaml. We would like this so that we can prioritize the server pod on our cluster.