### PR TITLE
Fix example variable name

### DIFF
--- a/gocd/values.yaml
+++ b/gocd/values.yaml
@@ -55,7 +55,7 @@ server:
   #  - "/backup_and_stop.sh"
   # server.terminationGracePeriodSeconds is the optional duration in seconds the gocd server pod needs to terminate gracefully.
   # Note: SIGTERM is issued immediately after the pod deletion request is sent. If the pod doesn't terminate, k8s waits for terminationGracePeriodSeconds before issuing SIGKILL.
-  # server.terminationGracePeriodSeconds: 60
+  # terminationGracePeriodSeconds: 60
   image:
     # server.image.repository is the GoCD Server image name
     repository: "gocd/gocd-server"

--- a/gocd/values.yaml
+++ b/gocd/values.yaml
@@ -280,7 +280,7 @@ agent:
   # agent.deployStrategy is the strategy explained in detail at https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
   # agent.terminationGracePeriodSeconds is the optional duration in seconds the gocd agent pods need to terminate gracefully.
   # Note: SIGTERM is issued immediately after the pod deletion request is sent. If the pod doesn't terminate, k8s waits for terminationGracePeriodSeconds before issuing SIGKILL.
-  # agent.terminationGracePeriodSeconds: 60
+  # terminationGracePeriodSeconds: 60
   deployStrategy: {}
   image:
     # agent.image.repository is the GoCD Agent image name


### PR DESCRIPTION
The example variable name should just be terminationGracePeriodSeconds.
Simply uncommenting the variable as is does not have the desired effect