### PR TITLE
Rework chart tests to use recent patched images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+### 1.39.5
+* [7eeb56c4](https://github.com/gocd/helm-chart/commit/7eeb56c4): Reworking chart testing to use recent images and avoid creating resources by default
 ### 1.39.4
 * [eba20d2](https://github.com/gocd/helm-chart/commit/eba20d2): Add ability to configure server and agent fsGroupChangePolicy
 ### 1.39.3

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ helm search repo gocd/gocd
 # License
 
 ```plain
-Copyright 2020 ThoughtWorks, Inc.
+Copyright 2021 ThoughtWorks, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/gocd/Chart.yaml
+++ b/gocd/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: gocd
 home: https://www.gocd.org/
-version: 1.39.4
+version: 1.39.5
 appVersion: 21.3.0
 description: GoCD is an open-source continuous delivery server to model and visualize complex workflows with ease.
 icon: https://gocd.github.io/assets/images/go-icon-black-192x192.png

--- a/gocd/README.md
+++ b/gocd/README.md
@@ -446,6 +446,17 @@ Possible states:
 |reuseTopLevelServiceAccount = false and name = 'agentSA'|The 'agentSA' service account will be used. The service account needs to exist and bound with the appropriate role. |
 |reuseTopLevelServiceAccount = true| The GoCD service account will be created and used for the agents in the specified namespace. The permissions associated with the GoCD SA are defined above.  |
 
+### Testing
+
+A basic [chart test](https://helm.sh/docs/topics/chart_tests/) is included in this chart. Resources required to use this are not created by default and must e enabled as below.
+
+| Parameter         | Description                                                                                               | Default                                          |
+|-------------------|-----------------------------------------------------------------------------------------------------------|--------------------------------------------------|
+| `tests.enabled`   | Enable creation of resoures to support Helm chart tests with `helm test`.                                 | `false`                                          |
+| `tests.batsImage` | Container image containing [BATS](https://github.com/bats-core/bats-core) binaries, required for testing. | `bats/bats:1.5.0`                                |
+| `tests.curlImage` | Container image that will run the tests; supplying curl, and able to run BATS.                            | `ghcr.io/patrickdappollonio/alpine-utils:latest` |
+
+
 # Adding plugins
 
 - Add the .jar file link from the releases section in the plugin's repo to the env.extraEnvVars section as a new environment variable.
@@ -506,7 +517,7 @@ GoCD agents outside of the Kubernetes cluster may connect to the GoCD server via
 # License
 
 ```plain
-Copyright 2020 ThoughtWorks, Inc.
+Copyright 2021 ThoughtWorks, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/gocd/ci/test-values.yaml
+++ b/gocd/ci/test-values.yaml
@@ -1,0 +1,2 @@
+tests:
+  enabled: true

--- a/gocd/templates/tests/gocd-test-config.yaml
+++ b/gocd/templates/tests/gocd-test-config.yaml
@@ -1,3 +1,4 @@
+{{- if and .Values.server.enabled .Values.tests.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -20,3 +21,4 @@ data:
     @test "Testing GoCD application is accessible through service" {
       curl --retry 2 --retry-delay 10 --retry-max-time {{ .Values.server.healthCheck.initialDelaySeconds }} http://{{ template "gocd.fullname" . }}-server:{{ .Values.server.service.httpPort }}/go
     }
+{{- end -}}

--- a/gocd/templates/tests/gocd-test.yaml
+++ b/gocd/templates/tests/gocd-test.yaml
@@ -1,42 +1,50 @@
-apiVersion: v1
-kind: Pod
+{{- if .Values.server.enabled }}
+{{- if .Values.tests.enabled }}
+apiVersion: batch/v1
+kind: Job
 metadata:
-  name: "{{ template "gocd.fullname" . }}-test-{{ randAlphaNum 5 | lower }}"
+  name: "{{ template "gocd.fullname" . }}-test"
   labels:
     app: {{ template "gocd.name" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
   annotations:
-    "helm.sh/hook": test-success
+    "helm.sh/hook": test
 spec:
-  initContainers:
-    - name: "test-framework"
-      image: "dduportal/bats:0.4.0"
-      command:
-        - "bash"
-        - "-c"
-        - |
-          set -ex
-          # copy bats to tools dir
-          cp -R /usr/local/libexec/ /tools/bats/
-      volumeMounts:
-        - mountPath: /tools
-          name: tools
-  containers:
-    - name: {{ template "gocd.name" . }}-ui-test
-      image: "gocddev/gocd-helm-build:v0.1.0"
-      command: ["/tools/bats/bats", "-t", "/tests/run.sh"]
-      volumeMounts:
-        - mountPath: /tests
-          name: tests
-          readOnly: true
-        - mountPath: /tools
-          name: tools
-  volumes:
-    - name: tests
-      configMap:
-        name: {{ template "gocd.fullname" . }}-tests
-    - name: tools
-      emptyDir: {}
-  restartPolicy: Never
+  activeDeadlineSeconds: 150
+  ttlSecondsAfterFinished: 180
+  template:
+    spec:
+      initContainers:
+        - name: "test-framework"
+          image: {{ .Values.tests.batsImage }}
+          command:
+            - "bash"
+            - "-c"
+            - |
+              set -ex
+              # copy bats to tools dir
+              cp -R /opt/bats/ /tools/bats/
+          volumeMounts:
+            - mountPath: /tools
+              name: tools
+      containers:
+        - name: {{ template "gocd.name" . }}-ui-test
+          image: {{ .Values.tests.curlImage }}
+          command: ["/tools/bats/bin/bats", "-t", "/tests/run.sh"]
+          volumeMounts:
+            - mountPath: /tests
+              name: tests
+              readOnly: true
+            - mountPath: /tools
+              name: tools
+      volumes:
+        - name: tests
+          configMap:
+            name: {{ template "gocd.fullname" . }}-tests
+        - name: tools
+          emptyDir: {}
+      restartPolicy: Never
+{{- end -}}
+{{- end -}}

--- a/gocd/values.yaml
+++ b/gocd/values.yaml
@@ -428,3 +428,12 @@ agent:
   ## Tolerations for allowing pods to be scheduled on nodes with matching taints
   ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
   tolerations: {}
+
+tests:
+  # Whether or not to create test resources for use in Helm chart testing.
+  # Without the resources being created the tests will not work; however the installation is cleaner.
+  enabled: true
+  # A BATS image to supply test runner
+  batsImage: "bats/bats:1.5.0"
+  # A image containing bash, curl and busybox|coreutils for executing tests
+  curlImage: "ghcr.io/patrickdappollonio/alpine-utils:latest"


### PR DESCRIPTION
- No longer creates the test config map by default; requiring opt-in with `tests.enabled=true` at install time to avoid cruft in people's clusters
- Switches to recently updated/patched Docker images rather than a special dev GoCD image
- Uses a Kubernetes Job rather than Pod, allowing for nicer cleanup of test resources after time