### PR TITLE
[GoCD Helm Chart] Bump up GoCD Version to 21.4.0

### DIFF
--- a/gocd/CHANGELOG.md
+++ b/gocd/CHANGELOG.md
@@ -1,3 +1,5 @@
+### 1.40.0
+* [b957448](https://github.com/gocd/helm-chart/commit/b957448): Bump up GoCD Version to 21.4.0
 ### 1.39.8
 * [6e265688](https://github.com/gocd/helm-chart/commit/6e265688): Add ability to configure ingressClassName (thanks to @chadlwilson)
 ### 1.39.7

--- a/gocd/Chart.yaml
+++ b/gocd/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: gocd
 home: https://www.gocd.org/
-version: 1.39.8
-appVersion: 21.3.0
+version: 1.40.0
+appVersion: 21.4.0
 description: GoCD is an open-source continuous delivery server to model and visualize complex workflows with ease.
 icon: https://gocd.github.io/assets/images/go-icon-black-192x192.png
 keywords:


### PR DESCRIPTION
PR to update the helm chart to the latest version of GoCD