### PR TITLE
Avoid using :latest image during Helm test

### DIFF
--- a/gocd/CHANGELOG.md
+++ b/gocd/CHANGELOG.md
@@ -1,3 +1,5 @@
+### 1.40.3
+* [e59be113](https://github.com/gocd/helm-chart/commit/e59be113): Use fixed SHA digest for helm test-related image (thanks to @chadlwilson)
 ### 1.40.2
 * [54b481fb](https://github.com/gocd/helm-chart/commit/54b481fb): Bump Alpine agent image version from 3.14 to 3.15 (thanks to @chadlwilson)
 ### 1.40.1

--- a/gocd/Chart.yaml
+++ b/gocd/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: gocd
 home: https://www.gocd.org/
-version: 1.40.2
+version: 1.40.3
 appVersion: 21.4.0
 description: GoCD is an open-source continuous delivery server to model and visualize complex workflows with ease.
 icon: https://gocd.github.io/assets/images/go-icon-black-192x192.png

--- a/gocd/values.yaml
+++ b/gocd/values.yaml
@@ -452,7 +452,7 @@ tests:
   # A BATS image to supply test runner
   batsImage: "bats/bats:1.5.0"
   # A image containing bash, curl and busybox|coreutils for executing tests
-  curlImage: "ghcr.io/patrickdappollonio/alpine-utils:latest"
+  curlImage: "ghcr.io/patrickdappollonio/alpine-utils@sha256:b056c88a61f995602ef289c32f17d2d07ea302cb12ee435abd83a6790a9cc83e"
   # Specify an array of imagePullSecrets to pull from private registries
   # You need to manually create secrets in the namespace
   # See https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/


### PR DESCRIPTION
**Description**

Switch to using a specific (validated) image digest during Helm test.

**Checklist**
<!-- 
 [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.]
 GoCD uses quasi-[semver](http://semver.org/)
 - Bump the major version if this is a breaking change to the chart that won't work with people's existing values.yaml or will add/remove resources in ways that potentially alter or degrade behaviour for their GoCD server/agent.
 - Generally we ony bump minor version for new GoCD versions
 - Bump the patch version for fixes or enhancements to the chart itself
-->
- [X] Chart version bumped in `Chart.yaml`
- [X] Any new variables have documentation and examples in `values.yaml`, even if commented out
- [X] Any new variables added to the `README.md`
- [X] Squash into a single commit (or explain why you'd prefer not to), except...
- [X] ...additional commit added for `CHANGELOG.md` entry
- [X] Helm lint + tests passing? <!--(you may need to wait for a maintainer to approve running your workflow)-->
