### PR TITLE
Bumps Kubernetes Elastic Agent plugin version from 3.7.1 to 3.8.0

### DIFF
--- a/gocd/CHANGELOG.md
+++ b/gocd/CHANGELOG.md
@@ -1,3 +1,5 @@
+### 1.40.5
+* [344a65bf](https://github.com/gocd/helm-chart/commit/344a65bf): Bump Kubernetes Elastic Agent plugin version from 3.7.1 to 3.8.0
 ### 1.40.4
 * [52edbcbb](https://github.com/gocd/helm-chart/commit/52edbcbb): Switch to a smaller helm test-related image (thanks to @chadlwilson)
 ### 1.40.3

--- a/gocd/Chart.yaml
+++ b/gocd/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: gocd
 home: https://www.gocd.org/
-version: 1.40.4
+version: 1.40.5
 appVersion: 21.4.0
 description: GoCD is an open-source continuous delivery server to model and visualize complex workflows with ease.
 icon: https://gocd.github.io/assets/images/go-icon-black-192x192.png

--- a/gocd/values.yaml
+++ b/gocd/values.yaml
@@ -138,7 +138,7 @@ server:
     #  server.env.extraEnvVars is the list of environment variables passed to GoCD Server
     extraEnvVars:
       - name: GOCD_PLUGIN_INSTALL_kubernetes-elastic-agents
-        value: https://github.com/gocd/kubernetes-elastic-agents/releases/download/v3.7.1-230/kubernetes-elastic-agent-3.7.1-230.jar
+        value: https://github.com/gocd/kubernetes-elastic-agents/releases/download/v3.8.0-283/kubernetes-elastic-agent-3.8.0-283.jar
       - name: GOCD_PLUGIN_INSTALL_docker-registry-artifact-plugin
         value: https://github.com/gocd/docker-registry-artifact-plugin/releases/download/v1.1.0-104/docker-registry-artifact-plugin-1.1.0-104.jar
   service:


### PR DESCRIPTION
<!--
 Thanks for contributing!

 Please check the following for your pull request to be reviewed and merged.

 - Describe what you are trying to achieve
 - Let us know what you have tested
 - Let us know about any possibly breaking changes or things you are not sure of
 -->

**Description**

Bumps Kubernetes Elastic Agent plugin version from 3.7.1 to 3.8.0

<!-- What are you trying to achieve with this change? What problem does it solve for users? -->

**Checklist**
<!-- 
 [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.]
 GoCD uses quasi-[semver](http://semver.org/)
 - Bump the major version if this is a breaking change to the chart that won't work with people's existing values.yaml or will add/remove resources in ways that potentially alter or degrade behaviour for their GoCD server/agent.
 - Generally we ony bump minor version for new GoCD versions
 - Bump the patch version for fixes or enhancements to the chart itself
-->
- [x] Chart version bumped in `Chart.yaml`
- [x] Any new variables have documentation and examples in `values.yaml`, even if commented out
- [x] Any new variables added to the `README.md`
- [x] Squash into a single commit (or explain why you'd prefer not to), except...
- [x] ...additional commit added for `CHANGELOG.md` entry
- [x] Helm lint + tests passing? <!--(you may need to wait for a maintainer to approve running your workflow)-->
