### PR TITLE
Remove deprecated `agent.env.agentAutoRegisterEnvironemnts` value

### DIFF
--- a/gocd/CHANGELOG.md
+++ b/gocd/CHANGELOG.md
@@ -1,3 +1,5 @@
+### 1.40.6
+* [c241e28f](https://github.com/gocd/helm-chart/commit/c241e28f): Remove deprecated `agent.env.agentAutoRegisterEnvironemnts` value which was scheduled for removal 3 years ago.
 ### 1.40.5
 * [344a65bf](https://github.com/gocd/helm-chart/commit/344a65bf): Bump Kubernetes Elastic Agent plugin version from 3.7.1 to 3.8.0
 ### 1.40.4

--- a/gocd/Chart.yaml
+++ b/gocd/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: gocd
 home: https://www.gocd.org/
-version: 1.40.5
+version: 1.40.6
 appVersion: 21.4.0
 description: GoCD is an open-source continuous delivery server to model and visualize complex workflows with ease.
 icon: https://gocd.github.io/assets/images/go-icon-black-192x192.png

--- a/gocd/templates/NOTES.txt
+++ b/gocd/templates/NOTES.txt
@@ -62,8 +62,3 @@
     ################################################################################################
 {{ end }}
 
-{{- if .Values.agent.env.agentAutoRegisterEnvironemnts -}}
-6. Deprecations
-   The property `agent.env.agentAutoRegisterEnvironemnts` is deprecated in favor of `agent.env.agentAutoRegisterEnvironments`.
-   Please note that the deprecated property will be removed in GoCD 19.3.0 (that is, when Chart.appVersion is 19.3.0). Users are encouraged to use the new property `agent.env.agentAutoRegisterEnvironments`.
-{{ end }}

--- a/gocd/templates/gocd-agent-deployment.yaml
+++ b/gocd/templates/gocd-agent-deployment.yaml
@@ -101,9 +101,6 @@ spec:
             {{- if .Values.agent.env.agentAutoRegisterEnvironments }}
             - name: AGENT_AUTO_REGISTER_ENVIRONMENTS
               value: {{ .Values.agent.env.agentAutoRegisterEnvironments }}
-            {{- else if .Values.agent.env.agentAutoRegisterEnvironemnts }}
-            - name: AGENT_AUTO_REGISTER_ENVIRONMENTS
-              value: {{ .Values.agent.env.agentAutoRegisterEnvironemnts }}
             {{- end }}
             {{- if .Values.agent.env.agentAutoRegisterHostname }}
             - name: AGENT_AUTO_REGISTER_HOSTNAME

--- a/gocd/values.yaml
+++ b/gocd/values.yaml
@@ -318,9 +318,6 @@ agent:
     # agent.env.agentAutoRegisterResources is the GoCD Agent auto-register resources
     agentAutoRegisterResources:
     # agent.env.agentAutoRegisterEnvironments is the GoCD Agent auto-register Environments
-    # deprecated because of a typo. Use agent.env.agentAutoRegisterEnvironments instead
-    agentAutoRegisterEnvironemnts:
-    # agent.env.agentAutoRegisterEnvironments is the GoCD Agent auto-register Environments
     agentAutoRegisterEnvironments:
     # agent.env.agentAutoRegisterHostname is the GoCD Agent auto-register hostname
     agentAutoRegisterHostname:


### PR DESCRIPTION
**Description**

<!-- What are you trying to achieve with this change? What problem does it solve for users? -->

This typoed value was scheduled for removal 3 years ago, but probably forgotten. Should be perfectly safe to remove now.

**Checklist**
<!-- 
 [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.]
 GoCD uses quasi-[semver](http://semver.org/)
 - Bump the major version if this is a breaking change to the chart that won't work with people's existing values.yaml or will add/remove resources in ways that potentially alter or degrade behaviour for their GoCD server/agent.
 - Generally we ony bump minor version for new GoCD versions
 - Bump the patch version for fixes or enhancements to the chart itself
-->
- [x] Chart version bumped in `Chart.yaml`
- [x] Any new variables have documentation and examples in `values.yaml`, even if commented out
- [x] Any new variables added to the `README.md`
- [x] Squash into a single commit (or explain why you'd prefer not to), except...
- [x] ...additional commit added for `CHANGELOG.md` entry
- [x] Helm lint + tests passing? <!--(you may need to wait for a maintainer to approve running your workflow)-->
