### PR TITLE
Bumps Docker Registry Artifact plugin version from 1.1.0 to 1.3.0

### DIFF
--- a/gocd/CHANGELOG.md
+++ b/gocd/CHANGELOG.md
@@ -1,3 +1,5 @@
+### 1.40.7
+* [6aa8bec7](https://github.com/gocd/helm-chart/commit/6aa8bec7): Bump Docker Registry Artifact plugin version from 1.1.0 to 1.3.0
 ### 1.40.6
 * [c241e28f](https://github.com/gocd/helm-chart/commit/c241e28f): Remove deprecated `agent.env.agentAutoRegisterEnvironemnts` value which was scheduled for removal 3 years ago.
 ### 1.40.5

--- a/gocd/Chart.yaml
+++ b/gocd/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: gocd
 home: https://www.gocd.org/
-version: 1.40.6
+version: 1.40.7
 appVersion: 21.4.0
 description: GoCD is an open-source continuous delivery server to model and visualize complex workflows with ease.
 icon: https://gocd.github.io/assets/images/go-icon-black-192x192.png

--- a/gocd/values.yaml
+++ b/gocd/values.yaml
@@ -140,7 +140,7 @@ server:
       - name: GOCD_PLUGIN_INSTALL_kubernetes-elastic-agents
         value: https://github.com/gocd/kubernetes-elastic-agents/releases/download/v3.8.0-283/kubernetes-elastic-agent-3.8.0-283.jar
       - name: GOCD_PLUGIN_INSTALL_docker-registry-artifact-plugin
-        value: https://github.com/gocd/docker-registry-artifact-plugin/releases/download/v1.1.0-104/docker-registry-artifact-plugin-1.1.0-104.jar
+        value: https://github.com/gocd/docker-registry-artifact-plugin/releases/download/v1.3.0-151/docker-registry-artifact-plugin-1.3.0-151.jar
   service:
     # server.service.type is the GoCD Server service type
     type: "NodePort"


### PR DESCRIPTION
<!--
 Thanks for contributing!

 Please check the following for your pull request to be reviewed and merged.

 - Describe what you are trying to achieve
 - Let us know what you have tested
 - Let us know about any possibly breaking changes or things you are not sure of
 -->

**Description**

Bumps Docker Registry Artifact plugin version from 1.1.0 to 1.3.0

**Checklist**
<!-- 
 [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.]
 GoCD uses quasi-[semver](http://semver.org/)
 - Bump the major version if this is a breaking change to the chart that won't work with people's existing values.yaml or will add/remove resources in ways that potentially alter or degrade behaviour for their GoCD server/agent.
 - Generally we ony bump minor version for new GoCD versions
 - Bump the patch version for fixes or enhancements to the chart itself
-->
- [x] Chart version bumped in `Chart.yaml`
- [x] Any new variables have documentation and examples in `values.yaml`, even if commented out
- [x] Any new variables added to the `README.md`
- [x] Squash into a single commit (or explain why you'd prefer not to), except...
- [x] ...additional commit added for `CHANGELOG.md` entry
- [x] Helm lint + tests passing? <!--(you may need to wait for a maintainer to approve running your workflow)-->
