### PR TITLE
[GoCD Helm Chart] Bump up GoCD Version to 22.1.0

### DIFF
--- a/gocd/CHANGELOG.md
+++ b/gocd/CHANGELOG.md
@@ -1,3 +1,5 @@
+### 1.41.0
+* [68a8a81](https://github.com/gocd/helm-chart/commit/68a8a81): Bump up GoCD Version to 22.1.0
 ### 1.40.8
 * [88d8bd96](https://github.com/gocd/helm-chart/commit/88d8bd96): Bump Kubernetes Elastic Agent plugin version from 3.8.0 to 3.8.1
 ### 1.40.7

--- a/gocd/Chart.yaml
+++ b/gocd/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: gocd
 home: https://www.gocd.org/
-version: 1.40.8
-appVersion: 21.4.0
+version: 1.41.0
+appVersion: 22.1.0
 description: GoCD is an open-source continuous delivery server to model and visualize complex workflows with ease.
 icon: https://gocd.github.io/assets/images/go-icon-black-192x192.png
 keywords:


### PR DESCRIPTION
PR to update the helm chart to the latest version of GoCD