### PR TITLE
[GoCD Helm Chart] Bump up GoCD Version to 22.2.0

### DIFF
--- a/gocd/CHANGELOG.md
+++ b/gocd/CHANGELOG.md
@@ -1,3 +1,5 @@
+### 1.42.0
+* [afd2c64](https://github.com/gocd/helm-chart/commit/afd2c64): Bump up GoCD Version to 22.2.0
 ### 1.41.1
 * [9a40e5ac](https://github.com/gocd/helm-chart/commit/9a40e5ac): Bump Kubernetes Elastic Agent plugin version from 3.8.1 to 3.8.2
 * [6c544cfd](https://github.com/gocd/helm-chart/commit/6c544cfd): Bump Docker Registry Artifact plugin version from 1.3.0 to 1.3.1

--- a/gocd/Chart.yaml
+++ b/gocd/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: gocd
 home: https://www.gocd.org/
-version: 1.41.1
-appVersion: 22.1.0
+version: 1.42.0
+appVersion: 22.2.0
 description: GoCD is an open-source continuous delivery server to model and visualize complex workflows with ease.
 icon: https://gocd.github.io/assets/images/go-icon-black-192x192.png
 keywords:


### PR DESCRIPTION
PR to update the helm chart to the latest version of GoCD