### PR TITLE
Bump versions of dependency tools/images

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -53,7 +53,7 @@ jobs:
       - name: Create kind cluster
         uses: helm/kind-action@v1.3.0
         with:
-          version: v0.14.0 # See https://github.com/kubernetes-sigs/kind/releases
+          version: v0.15.0 # See https://github.com/kubernetes-sigs/kind/releases
           node_image: kindest/node:${{ matrix.k8s }}
         # Only build a kind cluster if there are chart changes to test.
         if: steps.list-changed.outputs.changed == 'true'

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@v3.3
         with:
-          version: v3.9.3 # See https://github.com/helm/helm/releases
+          version: v3.9.4 # See https://github.com/helm/helm/releases
 
       - uses: actions/setup-python@v4
         with:

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -16,10 +16,11 @@ jobs:
         k8s: # See https://hub.docker.com/r/kindest/node/tags and https://endoflife.date/kubernetes
           - v1.19.16 # EOL 2021-10-28
           - v1.20.15 # EOL 2022-02-28
-          - v1.21.12 # EOL 2022-06-28
-          - v1.22.9  # EOL 2022-10-28
-          - v1.23.6  # EOL 2023-02-28
-          - v1.24.3  # EOL 2023-09-29
+          - v1.21.14 # EOL 2022-06-28
+          - v1.22.13 # EOL 2022-10-28
+          - v1.23.10 # EOL 2023-02-28
+          - v1.24.4  # EOL 2023-07-28
+          - v1.25.0  # EOL 2023-10-27
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@v3.3
         with:
-          version: v3.9.3
+          version: v3.9.4
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.4.0

--- a/gocd/CHANGELOG.md
+++ b/gocd/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 1.42.2
+* [1b19b4e1](https://github.com/gocd/helm-chart/commit/1b19b4e1): Use GoCD Agent Alpine 3.16 images by default
+* [ebcf1558](https://github.com/gocd/helm-chart/commit/ebcf1558), [4e302d26](https://github.com/gocd/helm-chart/commit/4e302d26): Bump testing images to later versions
 ### 1.42.1
 * [0df35fa1](https://github.com/gocd/helm-chart/commit/0df35fa1): Bump testing images to later versions
 ### 1.42.0

--- a/gocd/Chart.yaml
+++ b/gocd/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: gocd
 home: https://www.gocd.org/
-version: 1.42.1
+version: 1.42.2
 appVersion: 22.2.0
 description: GoCD is an open-source continuous delivery server to model and visualize complex workflows with ease.
 icon: https://gocd.github.io/assets/images/go-icon-black-192x192.png

--- a/gocd/values.yaml
+++ b/gocd/values.yaml
@@ -300,7 +300,7 @@ agent:
   deployStrategy: {}
   image:
     # agent.image.repository is the GoCD Agent image name
-    repository: "gocd/gocd-agent-alpine-3.15"
+    repository: "gocd/gocd-agent-alpine-3.16"
     # agent.image.tag is the GoCD Agent image's tag
     tag:
     # agent.image.pullPolicy is the GoCD Agent image's pull policy

--- a/gocd/values.yaml
+++ b/gocd/values.yaml
@@ -446,8 +446,8 @@ tests:
   # Whether or not to create test resources for use in Helm chart testing.
   # Without the resources being created the tests will not work; however the installation is cleaner.
   enabled: false
-  # A BATS image to supply test runner
-  batsImage: "bats/bats:1.7.0"
+  # A BATS image to supply test runner, see https://hub.docker.com/r/bats/bats/tags
+  batsImage: "bats/bats:1.8.0"
   # A image containing bash, curl and busybox|coreutils for executing tests
   curlImage: "ghcr.io/containeroo/alpine-toolbox:2.0.11"
   # Specify an array of imagePullSecrets to pull from private registries

--- a/gocd/values.yaml
+++ b/gocd/values.yaml
@@ -448,8 +448,8 @@ tests:
   enabled: false
   # A BATS image to supply test runner, see https://hub.docker.com/r/bats/bats/tags
   batsImage: "bats/bats:1.8.0"
-  # A image containing bash, curl and busybox|coreutils for executing tests
-  curlImage: "ghcr.io/containeroo/alpine-toolbox:2.0.11"
+  # A image containing bash, curl and busybox|coreutils for executing tests, see https://github.com/containeroo/alpine-toolbox/releases
+  curlImage: "ghcr.io/containeroo/alpine-toolbox:2.0.15"
   # Specify an array of imagePullSecrets to pull from private registries
   # You need to manually create secrets in the namespace
   # See https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/


### PR DESCRIPTION

**Description**

Updates versions of testing tools and images to latest versions.

**Checklist**
<!-- 
 [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.]
 GoCD uses quasi-[semver](http://semver.org/)
 - Bump the major version if this is a breaking change to the chart that won't work with people's existing values.yaml or will add/remove resources in ways that potentially alter or degrade behaviour for their GoCD server/agent.
 - Generally we ony bump minor version for new GoCD versions
 - Bump the patch version for fixes or enhancements to the chart itself
-->
- [x] Chart version bumped in `Chart.yaml`
- [x] Any new variables have documentation and examples in `values.yaml`, even if commented out
- [x] Any new variables added to the `README.md`
- [x] Squash into a single commit (or explain why you'd prefer not to), except...
- [x] ...additional commit added for `CHANGELOG.md` entry
- [x] Helm lint + tests passing? <!--(you may need to wait for a maintainer to approve running your workflow)-->
