### PR TITLE
Bump K8s image versions

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -17,10 +17,10 @@ jobs:
           - v1.19.16 # EOL 2021-10-28
           - v1.20.15 # EOL 2022-02-28
           - v1.21.14 # EOL 2022-06-28
-          - v1.22.13 # EOL 2022-10-28
-          - v1.23.10 # EOL 2023-02-28
-          - v1.24.4  # EOL 2023-07-28
-          - v1.25.0  # EOL 2023-10-27
+          - v1.22.15 # EOL 2022-10-28
+          - v1.23.12 # EOL 2023-02-28
+          - v1.24.6  # EOL 2023-07-28
+          - v1.25.2  # EOL 2023-10-27
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -53,7 +53,6 @@ jobs:
       - name: Create kind cluster
         uses: helm/kind-action@v1.4.0
         with:
-          version: v0.15.0 # See https://github.com/kubernetes-sigs/kind/releases
           node_image: kindest/node:${{ matrix.k8s }}
         # Only build a kind cluster if there are chart changes to test.
         if: steps.list-changed.outputs.changed == 'true'


### PR DESCRIPTION
Also revert to default kind version that comes with the action. They seem to be updating this in a timely fashion now.