### PR TITLE
[GoCD Helm Chart] Bump up GoCD Version to 22.3.0

### DIFF
--- a/gocd/CHANGELOG.md
+++ b/gocd/CHANGELOG.md
@@ -1,3 +1,5 @@
+### 1.43.0
+* [d685e31](https://github.com/gocd/helm-chart/commit/d685e31): Bump up GoCD Version to 22.3.0
 ### 1.42.2
 * [1b19b4e1](https://github.com/gocd/helm-chart/commit/1b19b4e1): Use GoCD Agent Alpine 3.16 images by default
 * [ebcf1558](https://github.com/gocd/helm-chart/commit/ebcf1558), [4e302d26](https://github.com/gocd/helm-chart/commit/4e302d26): Bump testing images to later versions

--- a/gocd/Chart.yaml
+++ b/gocd/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: gocd
 home: https://www.gocd.org/
-version: 1.42.2
-appVersion: 22.2.0
+version: 1.43.0
+appVersion: 22.3.0
 description: GoCD is an open-source continuous delivery server to model and visualize complex workflows with ease.
 icon: https://gocd.github.io/assets/images/go-icon-black-192x192.png
 keywords:


### PR DESCRIPTION
PR to update the helm chart to the latest version of GoCD