### PR TITLE
Drop compatibility with EOL Kubernetes versions

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@v3.4
         with:
-          version: v3.9.4 # See https://github.com/helm/helm/releases
+          version: v3.10.1 # See https://github.com/helm/helm/releases
 
       - uses: actions/setup-python@v4
         with:

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -34,7 +34,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.11'
 
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2.3.1

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -14,13 +14,12 @@ jobs:
     strategy:
       matrix:
         k8s: # See https://hub.docker.com/r/kindest/node/tags and https://endoflife.date/kubernetes
-          - v1.19.16 # EOL 2021-10-28
           - v1.20.15 # EOL 2022-02-28
           - v1.21.14 # EOL 2022-06-28
           - v1.22.15 # EOL 2022-10-28
-          - v1.23.12 # EOL 2023-02-28
-          - v1.24.6  # EOL 2023-07-28
-          - v1.25.2  # EOL 2023-10-27
+          - v1.23.13 # EOL 2023-02-28
+          - v1.24.7  # EOL 2023-07-28
+          - v1.25.3  # EOL 2023-10-27
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@v3.4
         with:
-          version: v3.9.4
+          version: v3.10.1
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.4.1

--- a/gocd/CHANGELOG.md
+++ b/gocd/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 2.0.0
+* [5f5f69a8](https://github.com/gocd/helm-chart/commit/5f5f69a8): Require Kubernetes 1.20+ for use with chart (drops support for EOL Kubernetes versions) (thanks to @chadlwilson)
+* [5f5f69a8](https://github.com/gocd/helm-chart/commit/5f5f69a8): Change default behaviour of persistent volumes to check permissions only on the root (thanks to @chadlwilson)
+* [54e7a937](https://github.com/gocd/helm-chart/commit/54e7a937): Bump pre-installed plugins to latest patched versions (thanks to @chadlwilson)
 ### 1.43.0
 * [d685e31](https://github.com/gocd/helm-chart/commit/d685e31): Bump up GoCD Version to 22.3.0
 ### 1.42.2

--- a/gocd/Chart.yaml
+++ b/gocd/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: gocd
 home: https://www.gocd.org/
-version: 1.43.0
+version: 2.0.0
 appVersion: 22.3.0
 description: GoCD is an open-source continuous delivery server to model and visualize complex workflows with ease.
 icon: https://gocd.github.io/assets/images/go-icon-black-192x192.png
@@ -17,11 +17,7 @@ keywords:
 sources:
 - https://github.com/gocd/gocd
 maintainers:
-- name: arvindsv
-  email: arvind@thoughtworks.com
-- name: ganeshspatil
-  email: ganeshpl@thoughtworks.com
-- name: varshavaradarajan
-  email: varshasvaradarajan@gmail.com
 - name: chadlwilson
   email: chadw@thoughtworks.com
+- name: arvindsv
+  email: arvind@thoughtworks.com

--- a/gocd/README.md
+++ b/gocd/README.md
@@ -13,7 +13,7 @@ To quickly build your first pipeline while learning key GoCD concepts, visit the
 ## Prerequisites
 
 - Helm 3 (Helm 2 _may_ work, but considered deprecated and may break)
-- Kubernetes 1.14+ with Beta APIs enabled
+- Kubernetes 1.20+
 - PV provisioner support in the underlying infrastructure
 - LoadBalancer support or Ingress Controller
 
@@ -79,8 +79,8 @@ The following tables list the configurable parameters of the GoCD chart and thei
 | `server.service.loadBalancerSourceRanges`    | GoCD server service Load Balancer source IP ranges to whitelist                                                                                      | `nil`                                      |
 | `server.service.httpPort`                    | GoCD server service HTTP port                                                                                                                        | `8153`                                     |
 | `server.service.nodeHttpPort`                | GoCD server service node HTTP port. **Note**: A random nodePort will get assigned if not specified                                                   | `nil`                                      |
-| `server.ingress.enabled`                     | Enable/disable GoCD ingress. Allow traffic from outside the cluster via http. Do `kubectl describe ing` to get the public ip for access              | `true`                                     |
-| `server.ingress.ingressClassName`            | Ingress class that GoCD ingress should use (K8S 1.18+)                                                                                               | `nil`                                      |
+| `server.ingress.enabled`                     | Enable/disable GoCD ingress. Allow traffic from outside the cluster via http. Do `kubectl describe ing` to get the public IP for access              | `true`                                     |
+| `server.ingress.ingressClassName`            | Ingress class that GoCD ingress should use                                                                                                           | `nil`                                      |
 | `server.ingress.hosts`                       | GoCD ingress hosts records.                                                                                                                          | `nil`                                      |
 | `server.ingress.annotations`                 | GoCD ingress annotations.                                                                                                                            | `{}`                                       |
 | `server.ingress.path`                        | GoCD ingress path.                                                                                                                                   | `/`                                        |
@@ -97,7 +97,7 @@ The following tables list the configurable parameters of the GoCD chart and thei
 | `server.securityContext.runAsUser`           | The container user for all the GoCD server pods.                                                                                                     | `1000`                                     |
 | `server.securityContext.runAsGroup`          | The container group for all the GoCD server pods.                                                                                                    | `0`                                        |
 | `server.securityContext.fsGroup`             | The container supplementary group for all the GoCD server pods.                                                                                      | `0`                                        |
-| `server.securityContext.fsGroupChangePolicy` | The policy for checking fsGroup permissions on GoCD server pods (K8S 1.20+)                                                                          | `Always`                                   |
+| `server.securityContext.fsGroupChangePolicy` | The policy for checking fsGroup permissions on GoCD server pods                                                                                      | `OnRootMismatch`                           |
 | `server.sidecarContainers`                   | Sidecar containers to run alongside GoCD server.                                                                                                     | `[]`                                       |
 
 #### Preconfiguring the GoCD Server
@@ -199,7 +199,7 @@ $ kubectl create secret generic gocd-server-ssh \
 | `agent.securityContext.runAsUser`           | The container user for all the GoCD agent pods.                                                                                                                                  | `1000`                        |
 | `agent.securityContext.runAsGroup`          | The container group for all the GoCD agent pods.                                                                                                                                 | `0`                           |
 | `agent.securityContext.fsGroup`             | The container supplementary group for all the GoCD agent pods.                                                                                                                   | `0`                           |
-| `agent.securityContext.fsGroupChangePolicy` | The policy for checking fsGroup permissions on GoCD agent pods (K8S 1.20+)                                                                                                       | `Always`                      |
+| `agent.securityContext.fsGroupChangePolicy` | The policy for checking fsGroup permissions on GoCD agent pods                                                                                                                   | `OnRootMismatch`              |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 
@@ -300,7 +300,7 @@ the defined `fsGroup`, as documented [here](https://kubernetes.io/blog/2020/12/1
 This can be extremely slow on large volume mounts and will be observed as your pod being stuck in `ContainerCreating`
 for a long period of time; with events on the pod related to volume mounting.
 
-From Kubernetes `1.20+` this behaviour can be changed using `server.securityContext.fsGroupChangePolicy` (and equivalent
+This behaviour can be changed using `server.securityContext.fsGroupChangePolicy` (and equivalent
 property for your GoCD agents if necessary), further [documented here](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#configure-volume-permission-and-ownership-change-policy-for-pods).
 
 ### Server persistence Values

--- a/gocd/templates/gocd-agent-deployment.yaml
+++ b/gocd/templates/gocd-agent-deployment.yaml
@@ -45,9 +45,7 @@ spec:
         runAsUser: {{ .Values.agent.securityContext.runAsUser }}
         runAsGroup: {{ .Values.agent.securityContext.runAsGroup }}
         fsGroup: {{ .Values.agent.securityContext.fsGroup }}
-        {{- if semverCompare ">=1.20-0" $.Capabilities.KubeVersion.Version }}
-        fsGroupChangePolicy: {{ .Values.agent.securityContext.fsGroupChangePolicy | default "Always" }}
-        {{- end }}
+        fsGroupChangePolicy: {{ .Values.agent.securityContext.fsGroupChangePolicy }}
       {{- if or .Values.agent.persistence.enabled (or .Values.agent.security.ssh.enabled .Values.agent.persistence.extraVolumes) }}
       volumes:
       {{- end }}

--- a/gocd/templates/gocd-server-deployment.yaml
+++ b/gocd/templates/gocd-server-deployment.yaml
@@ -43,9 +43,7 @@ spec:
         runAsUser: {{ .Values.server.securityContext.runAsUser }}
         runAsGroup: {{ .Values.server.securityContext.runAsGroup }}
         fsGroup: {{ .Values.server.securityContext.fsGroup }}
-        {{- if semverCompare ">=1.20-0" $.Capabilities.KubeVersion.Version }}
-        fsGroupChangePolicy: {{ .Values.server.securityContext.fsGroupChangePolicy | default "Always" }}
-        {{- end }}
+        fsGroupChangePolicy: {{ .Values.server.securityContext.fsGroupChangePolicy }}
       serviceAccountName: {{ template "gocd.serviceAccountName" . }}
       {{- if or .Values.server.shouldPreconfigure (or .Values.server.persistence.enabled (or .Values.server.security.ssh.enabled .Values.server.persistence.extraVolumes)) }}
       volumes:

--- a/gocd/templates/ingress.yaml
+++ b/gocd/templates/ingress.yaml
@@ -1,11 +1,7 @@
 {{- if .Values.server.enabled }}
 {{- if .Values.server.ingress.enabled -}}
 {{- $extraPaths := .Values.server.ingress.extraPaths -}}
-{{- if semverCompare "<1.19-0" .Capabilities.KubeVersion.Version -}}
-apiVersion: networking.k8s.io/v1beta1
-{{- else }}
 apiVersion: networking.k8s.io/v1
-{{- end }}
 kind: Ingress
 metadata:
   name: {{ template "gocd.fullname" . }}-server
@@ -34,32 +30,19 @@ spec:
 {{ toYaml $extraPaths | indent 10 }}
         {{- end }}
           - path: {{ $.Values.server.ingress.path }}
-            {{- if semverCompare ">=1.18-0" $.Capabilities.KubeVersion.Version }}
             pathType: {{ default "ImplementationSpecific" $.Values.server.ingress.pathType }}
-            {{- end }}
             backend:
-              {{- if semverCompare "<1.19-0" $.Capabilities.KubeVersion.Version }}
-              serviceName: {{ template "gocd.fullname" $dot }}-server
-              servicePort: {{ $dot.Values.server.service.httpPort }}
-              {{- else }}
               service:
                 name: {{ template "gocd.fullname" $dot }}-server
                 port:
                   number: {{ $dot.Values.server.service.httpPort }}
-              {{- end }}
     {{- end }}
-  {{- else }}
-  {{- if semverCompare "<1.19-0" .Capabilities.KubeVersion.Version }}
-  backend:
-    serviceName: {{ template "gocd.fullname" . }}-server
-    servicePort: {{ .Values.server.service.httpPort }}
   {{- else }}
   defaultBackend:
     service:
       name: {{ template "gocd.fullname" . }}-server
       port:
         number: {{ .Values.server.service.httpPort }}
-  {{- end -}}
   {{- end -}}
   {{- if .Values.server.ingress.tls }}
   tls:

--- a/gocd/values.yaml
+++ b/gocd/values.yaml
@@ -138,9 +138,9 @@ server:
     #  server.env.extraEnvVars is the list of environment variables passed to GoCD Server
     extraEnvVars:
       - name: GOCD_PLUGIN_INSTALL_kubernetes-elastic-agents
-        value: https://github.com/gocd/kubernetes-elastic-agents/releases/download/v3.8.2-320/kubernetes-elastic-agent-3.8.2-320.jar
+        value: https://github.com/gocd/kubernetes-elastic-agents/releases/download/v3.8.2-350/kubernetes-elastic-agent-3.8.2-350.jar
       - name: GOCD_PLUGIN_INSTALL_docker-registry-artifact-plugin
-        value: https://github.com/gocd/docker-registry-artifact-plugin/releases/download/v1.3.1-270/docker-registry-artifact-plugin-1.3.1-270.jar
+        value: https://github.com/gocd/docker-registry-artifact-plugin/releases/download/v1.3.1-329/docker-registry-artifact-plugin-1.3.1-329.jar
   service:
     # server.service.type is the GoCD Server service type
     type: "NodePort"

--- a/gocd/values.yaml
+++ b/gocd/values.yaml
@@ -447,9 +447,9 @@ tests:
   # Without the resources being created the tests will not work; however the installation is cleaner.
   enabled: false
   # A BATS image to supply test runner, see https://hub.docker.com/r/bats/bats/tags
-  batsImage: "bats/bats:1.8.0"
+  batsImage: "bats/bats:1.8.2"
   # A image containing bash, curl and busybox|coreutils for executing tests, see https://github.com/containeroo/alpine-toolbox/releases
-  curlImage: "ghcr.io/containeroo/alpine-toolbox:2.0.15"
+  curlImage: "ghcr.io/containeroo/alpine-toolbox:2.0.20"
   # Specify an array of imagePullSecrets to pull from private registries
   # You need to manually create secrets in the namespace
   # See https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/

--- a/gocd/values.yaml
+++ b/gocd/values.yaml
@@ -44,8 +44,8 @@ server:
     runAsGroup: 0
     # Specify the container supplementary group for the GoCD server pod
     fsGroup: 0
-    # Specify the policy for checking volume permissions on K8S 1.20+.
-    # fsGroupChangePolicy: "OnRootMismatch"
+    # Specify the policy for checking volume permissions
+    fsGroupChangePolicy: "OnRootMismatch"
   # server.shouldPreconfigure is used to invoke a script to pre configure the elastic agent profile and the plugin settings in the GoCD server.
   # Note: If this value is set to true, then, the serviceAccount.name is configured for the GoCD server pod. The service account token is mounted as a secret and is used in the lifecycle hook.
   # Note: An attempt to preconfigure the GoCD server is made. There are cases where the pre-configuration can fail and the GoCD server starts with an empty config.
@@ -163,7 +163,7 @@ server:
     # server.ingress.enabled is the toggle to enable/disable GoCD Server Ingress
     enabled: true
 
-    # On Kubernetes 1.18+, use ingressClassName to override the default ingress class selection
+    # Override the default ingress class selection
     # ingressClassName: nginx
 
     # server.ingress.hosts is used to create an Ingress record.
@@ -281,8 +281,8 @@ agent:
     runAsGroup: 0
     # Specify the container supplementary group for all the GoCD agent pods
     fsGroup: 0
-    # Specify the policy for checking volume permissions on K8S 1.20+
-    # fsGroupChangePolicy: "OnRootMismatch"
+    # Specify the policy for checking volume permissions
+    fsGroupChangePolicy: "OnRootMismatch"
   # agent.replicaCount is the GoCD Agent replicas Count. Specify the number of GoCD agents to run
   replicaCount: 0
   # agent.preStop - array of command and arguments to run in the agent pre-stop lifecycle hook


### PR DESCRIPTION

**Description**

- Simplifies chart by requiring Kubernetes 1.20+ and dropping all outdated versions
- Changes defaults for persistent volumes to only check permissions on the root, which will speed start-ups for the vast majority of folks


**Possible challenges**

<!-- Is this a breaking change? Are there things you're not sure of? -->
This is a breaking change - if you try and install the chart on Kubenetes 1.19 or earlier, it will fail validation

**Checklist**
<!-- 
 [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.]
 GoCD uses quasi-[semver](http://semver.org/)
 - Bump the major version if this is a breaking change to the chart that won't work with people's existing values.yaml or will add/remove resources in ways that potentially alter or degrade behaviour for their GoCD server/agent.
 - Generally we ony bump minor version for new GoCD versions
 - Bump the patch version for fixes or enhancements to the chart itself
-->
- [x] Chart version bumped in `Chart.yaml`
- [x] Any new variables have documentation and examples in `values.yaml`, even if commented out
- [x] Any new variables added to the `README.md`
- [x] ...additional commit added for `CHANGELOG.md` entry
- [x] Helm lint + tests passing? <!--(you may need to wait for a maintainer to approve running your workflow)-->
