### PR TITLE
Bump plugins and testing tools to latest versions

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -14,12 +14,12 @@ jobs:
     strategy:
       matrix:
         k8s: # See https://hub.docker.com/r/kindest/node/tags and https://endoflife.date/kubernetes
-          - v1.20.15 # EOL 2022-02-28
           - v1.21.14 # EOL 2022-06-28
           - v1.22.15 # EOL 2022-10-28
           - v1.23.13 # EOL 2023-02-28
           - v1.24.7  # EOL 2023-07-28
           - v1.25.3  # EOL 2023-10-27
+          - v1.26.0  # EOL 2024-02-28
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -29,7 +29,7 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@v3.4
         with:
-          version: v3.10.1 # See https://github.com/helm/helm/releases
+          version: v3.10.2 # See https://github.com/helm/helm/releases
 
       - uses: actions/setup-python@v4
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@v3.4
         with:
-          version: v3.10.1
+          version: v3.10.2
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.4.1

--- a/gocd/CHANGELOG.md
+++ b/gocd/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 2.0.1
+* Test against Kubernetes 1.26.0 (thanks to @chadlwilson)
+* Bump pre-installed plugins to latest patched versions (thanks to @chadlwilson)
 ### 2.0.0
 * [5f5f69a8](https://github.com/gocd/helm-chart/commit/5f5f69a8): Require Kubernetes 1.20+ for use with chart (drops support for EOL Kubernetes versions) (thanks to @chadlwilson)
 * [5f5f69a8](https://github.com/gocd/helm-chart/commit/5f5f69a8): Change default behaviour of persistent volumes to check permissions only on the root (thanks to @chadlwilson)

--- a/gocd/Chart.yaml
+++ b/gocd/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: gocd
 home: https://www.gocd.org/
-version: 2.0.0
+version: 2.0.1
 appVersion: 22.3.0
 description: GoCD is an open-source continuous delivery server to model and visualize complex workflows with ease.
 icon: https://gocd.github.io/assets/images/go-icon-black-192x192.png

--- a/gocd/values.yaml
+++ b/gocd/values.yaml
@@ -140,7 +140,7 @@ server:
       - name: GOCD_PLUGIN_INSTALL_kubernetes-elastic-agents
         value: https://github.com/gocd/kubernetes-elastic-agents/releases/download/v3.8.2-350/kubernetes-elastic-agent-3.8.2-350.jar
       - name: GOCD_PLUGIN_INSTALL_docker-registry-artifact-plugin
-        value: https://github.com/gocd/docker-registry-artifact-plugin/releases/download/v1.3.1-329/docker-registry-artifact-plugin-1.3.1-329.jar
+        value: https://github.com/gocd/docker-registry-artifact-plugin/releases/download/v1.3.1-345/docker-registry-artifact-plugin-1.3.1-345.jar
   service:
     # server.service.type is the GoCD Server service type
     type: "NodePort"

--- a/gocd/values.yaml
+++ b/gocd/values.yaml
@@ -449,7 +449,7 @@ tests:
   # A BATS image to supply test runner, see https://hub.docker.com/r/bats/bats/tags
   batsImage: "bats/bats:1.8.2"
   # A image containing bash, curl and busybox|coreutils for executing tests, see https://github.com/containeroo/alpine-toolbox/releases
-  curlImage: "ghcr.io/containeroo/alpine-toolbox:2.0.20"
+  curlImage: "ghcr.io/containeroo/alpine-toolbox:2.0.27"
   # Specify an array of imagePullSecrets to pull from private registries
   # You need to manually create secrets in the namespace
   # See https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/

--- a/gocd/values.yaml
+++ b/gocd/values.yaml
@@ -138,7 +138,7 @@ server:
     #  server.env.extraEnvVars is the list of environment variables passed to GoCD Server
     extraEnvVars:
       - name: GOCD_PLUGIN_INSTALL_kubernetes-elastic-agents
-        value: https://github.com/gocd/kubernetes-elastic-agents/releases/download/v3.8.2-350/kubernetes-elastic-agent-3.8.2-350.jar
+        value: https://github.com/gocd/kubernetes-elastic-agents/releases/download/v3.8.2-356/kubernetes-elastic-agent-3.8.2-356.jar
       - name: GOCD_PLUGIN_INSTALL_docker-registry-artifact-plugin
         value: https://github.com/gocd/docker-registry-artifact-plugin/releases/download/v1.3.1-345/docker-registry-artifact-plugin-1.3.1-345.jar
   service:


### PR DESCRIPTION
**Description**

- Bumps pre-installed plugins to latest versions
- Tests against Kubernetes 1.26
- Bumps test tooling images to latest versions
 
**Checklist**
<!-- 
 [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.]
 GoCD uses quasi-[semver](http://semver.org/)
 - Bump the major version if this is a breaking change to the chart that won't work with people's existing values.yaml or will add/remove resources in ways that potentially alter or degrade behaviour for their GoCD server/agent.
 - Generally we ony bump minor version for new GoCD versions
 - Bump the patch version for fixes or enhancements to the chart itself
-->
- [x] Chart version bumped in `Chart.yaml`
- [x] Any new variables have documentation and examples in `values.yaml`, even if commented out
- [x] Any new variables added to the `README.md`
- [x] Squash into a single commit (or explain why you'd prefer not to), except...
- [x] ...additional commit added for `CHANGELOG.md` entry
- [x] Helm lint + tests passing? <!--(you may need to wait for a maintainer to approve running your workflow)-->
