### PR TITLE
Remove unnecessary ClusterRole permissions

### DIFF
--- a/gocd/CHANGELOG.md
+++ b/gocd/CHANGELOG.md
@@ -1,3 +1,5 @@
+### 2.0.3
+* Remove permissions unnecessary for elastic agents from default ClusterRole
 ### 2.0.2
 * Bump pre-installed plugins to latest patched versions (thanks to @chadlwilson)
 * Bump Helm test tools to latest versions (thanks to @chadlwilson)

--- a/gocd/Chart.yaml
+++ b/gocd/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: gocd
 home: https://www.gocd.org/
-version: 2.0.2
+version: 2.0.3
 appVersion: 22.3.0
 description: GoCD is an open-source continuous delivery server to model and visualize complex workflows with ease.
 icon: https://gocd.github.io/assets/images/go-icon-black-192x192.png

--- a/gocd/templates/gocd-ea-cluster-role.yaml
+++ b/gocd/templates/gocd-ea-cluster-role.yaml
@@ -17,13 +17,9 @@ rules:
 - apiGroups: [""]
   resources:
   - nodes
-  verbs: ["get", "list"]
+  verbs: ["list"]
 - apiGroups: [""]
   resources:
   - events
-  verbs: ["list", "watch"]
-- apiGroups: [""]
-  resources:
-  - namespaces
-  verbs: ["get"]
+  verbs: ["list"]
 {{ end }}


### PR DESCRIPTION
These permissions seem unnecessary for the elastic agent plugin to function.
- nodes are not individually retrieved
- events do not appear to be watched
- namespaces are not retrieved like this