### PR TITLE
fix indent.

### DIFF
--- a/gocd/CHANGELOG.md
+++ b/gocd/CHANGELOG.md
@@ -1,4 +1,6 @@
 ### 2.0.3
+* Fixed indentation misalignment in gocd-agent-deployment
+### 2.0.3
 * Remove permissions unnecessary for elastic agents from default ClusterRole
 ### 2.0.2
 * Bump pre-installed plugins to latest patched versions (thanks to @chadlwilson)

--- a/gocd/CHANGELOG.md
+++ b/gocd/CHANGELOG.md
@@ -1,4 +1,4 @@
-### 2.0.3
+### 2.0.4
 * Fixed indentation misalignment in gocd-agent-deployment
 ### 2.0.3
 * Remove permissions unnecessary for elastic agents from default ClusterRole

--- a/gocd/Chart.yaml
+++ b/gocd/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: gocd
 home: https://www.gocd.org/
-version: 2.0.3
+version: 2.0.4
 appVersion: 22.3.0
 description: GoCD is an open-source continuous delivery server to model and visualize complex workflows with ease.
 icon: https://gocd.github.io/assets/images/go-icon-black-192x192.png

--- a/gocd/templates/gocd-agent-deployment.yaml
+++ b/gocd/templates/gocd-agent-deployment.yaml
@@ -157,13 +157,13 @@ spec:
             {{- if .Values.agent.preStop }}
             preStop:
               exec:
-               command:
+                command:
 {{ toYaml .Values.agent.preStop | indent 18 }}
             {{- end }}
             {{- if .Values.agent.postStart }}
             postStart:
               exec:
-               command:
+                command:
 {{ toYaml .Values.agent.postStart | indent 18 }}
             {{- end }}
           {{- end }}


### PR DESCRIPTION
**Description**

There was an indentation misalignment in gocd-agent-deployment, which has been corrected.

**Relevant issues**

- Noting

**Possible challenges**

There is no possibility of breakage since the indentation is only corrected.

**Checklist**
<!-- 
 [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.]
 GoCD uses quasi-[semver](http://semver.org/)
 - Bump the major version if this is a breaking change to the chart that won't work with people's existing values.yaml or will add/remove resources in ways that potentially alter or degrade behaviour for their GoCD server/agent.
 - Generally we ony bump minor version for new GoCD versions
 - Bump the patch version for fixes or enhancements to the chart itself
-->
- [X] Chart version bumped in `Chart.yaml`
- [X] Any new variables have documentation and examples in `values.yaml`, even if commented out
- [X] Any new variables added to the `README.md`
- [X] Squash into a single commit (or explain why you'd prefer not to), except...
- [X] ...additional commit added for `CHANGELOG.md` entry
- [X] Helm lint + tests passing? <!--(you may need to wait for a maintainer to approve running your workflow)-->
