### PR TITLE
Bump tool versions

### DIFF
--- a/gocd/CHANGELOG.md
+++ b/gocd/CHANGELOG.md
@@ -1,3 +1,5 @@
+### 2.1.1
+* Bump Chart test tool images to latest patched versions (thanks to @chadlwilson)
 ### 2.1.0
 * [2b8f3fa](https://github.com/gocd/helm-chart/commit/2b8f3fa): Bump up GoCD Version to 23.1.0
 ### 2.0.4

--- a/gocd/Chart.yaml
+++ b/gocd/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: gocd
 home: https://www.gocd.org/
-version: 2.1.0
+version: 2.1.1
 appVersion: 23.1.0
 description: GoCD is an open-source continuous delivery server to model and visualize complex workflows with ease.
 icon: https://gocd.github.io/assets/images/go-icon-black-192x192.png

--- a/gocd/values.yaml
+++ b/gocd/values.yaml
@@ -447,9 +447,9 @@ tests:
   # Without the resources being created the tests will not work; however the installation is cleaner.
   enabled: false
   # A BATS image to supply test runner, see https://hub.docker.com/r/bats/bats/tags
-  batsImage: "bats/bats:1.8.2"
+  batsImage: "bats/bats:1.9.0"
   # A image containing bash, curl and busybox|coreutils for executing tests, see https://github.com/containeroo/alpine-toolbox/releases
-  curlImage: "ghcr.io/containeroo/alpine-toolbox:2.0.29"
+  curlImage: "ghcr.io/containeroo/alpine-toolbox:2.0.40"
   # Specify an array of imagePullSecrets to pull from private registries
   # You need to manually create secrets in the namespace
   # See https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/


### PR DESCRIPTION
**Checklist**
<!-- 
 [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.]
 GoCD uses quasi-[semver](http://semver.org/)
 - Bump the major version if this is a breaking change to the chart that won't work with people's existing values.yaml or will add/remove resources in ways that potentially alter or degrade behaviour for their GoCD server/agent.
 - Generally we ony bump minor version for new GoCD versions
 - Bump the patch version for fixes or enhancements to the chart itself
-->
- [x] Chart version bumped in `Chart.yaml`
- [x] Any new variables have documentation and examples in `values.yaml`, even if commented out
- [x] Any new variables added to the `README.md`
- [x] Squash into a single commit (or explain why you'd prefer not to), except...
- [x] ...additional commit added for `CHANGELOG.md` entry
- [x] Helm lint + tests passing? <!--(you may need to wait for a maintainer to approve running your workflow)-->
