### PR TITLE
[GoCD Helm Chart] Bump up GoCD Version to 23.2.0

### DIFF
--- a/gocd/CHANGELOG.md
+++ b/gocd/CHANGELOG.md
@@ -1,3 +1,5 @@
+### 2.3.0
+* [18b0f88](https://github.com/gocd/helm-chart/commit/18b0f88): Bump up GoCD Version to 23.2.0
 ### 2.2.0
 * [1c5f283](https://github.com/gocd/helm-chart/commit/1c5f283): Bump up GoCD Version to 23.2.0
 ### 2.1.8

--- a/gocd/Chart.yaml
+++ b/gocd/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: gocd
 home: https://www.gocd.org/
-version: 2.2.0
+version: 2.3.0
 appVersion: 23.2.0
 description: GoCD is an open-source continuous delivery server to model and visualize complex workflows with ease.
 icon: https://gocd.github.io/assets/images/go-icon-black-192x192.png


### PR DESCRIPTION
PR to update the helm chart to the latest version of GoCD