### PR TITLE
[GoCD Helm Chart] Bump up GoCD Version to 23.3.0

### DIFF
--- a/gocd/CHANGELOG.md
+++ b/gocd/CHANGELOG.md
@@ -1,3 +1,5 @@
+### 2.3.0
+* [c8a6601](https://github.com/gocd/helm-chart/commit/c8a6601): Bump up GoCD Version to 23.3.0
 ### 2.2.1
 * Change default agent image to one baed on Alpine 3.18
 ### 2.2.0

--- a/gocd/Chart.yaml
+++ b/gocd/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: gocd
 home: https://www.gocd.org/
-version: 2.2.1
-appVersion: 23.2.0
+version: 2.3.0
+appVersion: 23.3.0
 description: GoCD is an open-source continuous delivery server to model and visualize complex workflows with ease.
 icon: https://gocd.github.io/assets/images/go-icon-black-192x192.png
 keywords:


### PR DESCRIPTION
PR to update the helm chart to the latest version of GoCD