### PR TITLE
Test against K8S 1.28

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -18,11 +18,12 @@ jobs:
       matrix:
         k8s: # See https://hub.docker.com/r/kindest/node/tags for valid tags
           # For relevant EOLs https://endoflife.date/kubernetes / https://endoflife.date/amazon-eks / https://endoflife.date/azure-kubernetes-service / https://endoflife.date/google-kubernetes-engine
-          - v1.23.17 # EOL 2023-02-28
+          - v1.23.17 # EOL 2023-02-28 (2023-10 for EKS)
           - v1.24.15 # EOL 2023-07-28
           - v1.25.11 # EOL 2023-10-27
           - v1.26.6  # EOL 2024-02-28
           - v1.27.3  # EOL 2024-06-28
+          - v1.28.0  # EOL 2024-10-28
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
https://kubernetes.io/blog/2023/08/15/kubernetes-v1-28-release/