### PR TITLE
[GoCD Helm Chart] Bump up GoCD Version to 23.5.0

### DIFF
--- a/gocd/CHANGELOG.md
+++ b/gocd/CHANGELOG.md
@@ -1,3 +1,5 @@
+### 2.5.0
+* [d42c7ea](https://github.com/gocd/helm-chart/commit/d42c7ea): Bump up GoCD Version to 23.5.0
 ### 2.4.3
 * Bump testing tool image to latest version
 ### 2.4.1

--- a/gocd/Chart.yaml
+++ b/gocd/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: gocd
 home: https://www.gocd.org/
-version: 2.4.3
-appVersion: 23.4.0
+version: 2.5.0
+appVersion: 23.5.0
 description: GoCD is an open-source continuous delivery server to model and visualize complex workflows with ease.
 icon: https://gocd.github.io/assets/images/go-icon-black-192x192.png
 keywords:


### PR DESCRIPTION
PR to update the helm chart to the latest version of GoCD