### PR TITLE
[GoCD Helm Chart] Bump up GoCD Version to 24.1.0

### DIFF
--- a/gocd/CHANGELOG.md
+++ b/gocd/CHANGELOG.md
@@ -1,3 +1,5 @@
+### 2.7.0
+* [b405512](https://github.com/gocd/helm-chart/commit/b405512): Bump up GoCD Version to 24.1.0
 * Update default agent image to gocd-agent-wolfi
 * Update kubernetes elastic agent plugin to [v4.1.0-539](https://github.com/gocd/kubernetes-elastic-agents/releases/tag/v4.1.0-539)
 ### 2.6.2

--- a/gocd/Chart.yaml
+++ b/gocd/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: gocd
 home: https://www.gocd.org/
-version: 2.6.2
-appVersion: 23.5.0
+version: 2.7.0
+appVersion: 24.1.0
 description: GoCD is an open-source continuous delivery server to model and visualize complex workflows with ease.
 icon: https://gocd.github.io/assets/images/go-icon-black-192x192.png
 keywords:


### PR DESCRIPTION
PR to update the helm chart to the latest version of GoCD