### PR TITLE
[GoCD Helm Chart] Bump up GoCD Version to 24.3.0

### DIFF
--- a/gocd/CHANGELOG.md
+++ b/gocd/CHANGELOG.md
@@ -1,3 +1,5 @@
+### 2.9.0
+* [1a17fc0](https://github.com/gocd/helm-chart/commit/1a17fc0): Bump up GoCD Version to 24.3.0
 ### 2.8.1
 * Bump pre-installed plugins to latest patched versions (thanks to @chadlwilson)
 ### 2.8.0

--- a/gocd/Chart.yaml
+++ b/gocd/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: gocd
 home: https://www.gocd.org/
-version: 2.8.1
-appVersion: 24.2.0
+version: 2.9.0
+appVersion: 24.3.0
 description: GoCD is an open-source continuous delivery server to model and visualize complex workflows with ease.
 icon: https://gocd.github.io/assets/images/go-icon-black-192x192.png
 keywords:


### PR DESCRIPTION
PR to update the helm chart to the latest version of GoCD