### PR TITLE
Ensure static agents are listening on accessible ports when health checks enabled

### DIFF
--- a/gocd/CHANGELOG.md
+++ b/gocd/CHANGELOG.md
@@ -1,3 +1,5 @@
+### 2.9.3
+* Ensure agent is listening on correct interface when health check enabled (thanks to @chadlwilson and @12345ieee)
 ### 2.9.2
 * Bump pre-installed plugins to latest patched versions (thanks to @chadlwilson)
 ### 2.9.1

--- a/gocd/Chart.yaml
+++ b/gocd/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: gocd
 home: https://www.gocd.org/
-version: 2.9.2
+version: 2.9.3
 appVersion: 24.3.0
 description: GoCD is an open-source continuous delivery server to model and visualize complex workflows with ease.
 icon: https://gocd.github.io/assets/images/go-icon-black-192x192.png

--- a/gocd/templates/gocd-agent-deployment.yaml
+++ b/gocd/templates/gocd-agent-deployment.yaml
@@ -105,9 +105,9 @@ spec:
             - name: AGENT_AUTO_REGISTER_HOSTNAME
               value: {{ .Values.agent.env.agentAutoRegisterHostname }}
             {{- end }}
-            {{- if .Values.agent.env.goAgentJvmOpts }}
+            {{- if or .Values.agent.healthCheck.enabled .Values.agent.env.goAgentJvmOpts }}
             - name: GOCD_AGENT_JVM_OPTS
-              value: {{ .Values.agent.env.goAgentJvmOpts }}
+              value: {{ if .Values.agent.healthCheck.enabled }}-Dgo.agent.status.api.bind.host=0.0.0.0{{ end }} {{ .Values.agent.env.goAgentJvmOpts }}
             {{- end }}
             {{- if .Values.agent.env.goAgentBootstrapperJvmArgs }}
             - name: AGENT_BOOTSTRAPPER_JVM_ARGS


### PR DESCRIPTION

**Description**

As noted in #106, the static agent health checks require additional configuration to work as they no longer listen on `0.0.0.0` by default for security reasons when running in other environments outside a Kubernetes pod sandbox.

This will automatically change the configuration if they are enabled.

**Relevant issues**

<!-- Link any issues it closes/fixes using #) -->
- fixes #106

**Checklist**
<!-- 
 [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.]
 GoCD uses quasi-[semver](http://semver.org/)
 - Bump the major version if this is a breaking change to the chart that won't work with people's existing values.yaml or will add/remove resources in ways that potentially alter or degrade behaviour for their GoCD server/agent.
 - Generally we ony bump minor version for new GoCD versions
 - Bump the patch version for fixes or enhancements to the chart itself
-->
- [x] Chart version bumped in `Chart.yaml`
- [x] Any new variables have documentation and examples in `values.yaml`, even if commented out
- [x] Any new variables added to the `README.md`
- [x] Squash into a single commit (or explain why you'd prefer not to), except...
- [x] ...additional commit added for `CHANGELOG.md` entry
- [x] Helm lint + tests passing? <!--(you may need to wait for a maintainer to approve running your workflow)-->
