### PR TITLE
[GoCD Helm Chart] Bump up GoCD Version to 24.4.0

### DIFF
--- a/gocd/CHANGELOG.md
+++ b/gocd/CHANGELOG.md
@@ -1,3 +1,5 @@
+### 2.10.0
+* [aa45b5f](https://github.com/gocd/helm-chart/commit/aa45b5f): Bump up GoCD Version to 24.4.0
 ### 2.9.3
 * Ensure agent is listening on correct interface when health check enabled (thanks to @chadlwilson and @12345ieee)
 ### 2.9.2

--- a/gocd/Chart.yaml
+++ b/gocd/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: gocd
 home: https://www.gocd.org/
-version: 2.9.3
-appVersion: 24.3.0
+version: 2.10.0
+appVersion: 24.4.0
 description: GoCD is an open-source continuous delivery server to model and visualize complex workflows with ease.
 icon: https://gocd.github.io/assets/images/go-icon-black-192x192.png
 keywords:


### PR DESCRIPTION
PR to update the helm chart to the latest version of GoCD