### PR TITLE
Switch to a Chainguard image for bash/curl style downloads

### DIFF
--- a/gocd/CHANGELOG.md
+++ b/gocd/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### 2.10.1
 * Switch to a Chainguard bash image for testing (thanks to @chadlwilson)
+* Bump pre-installed plugins to latest patched versions (thanks to @chadlwilson)
 ### 2.10.0
 * [aa45b5f](https://github.com/gocd/helm-chart/commit/aa45b5f): Bump up GoCD Version to 24.4.0
 ### 2.9.3

--- a/gocd/CHANGELOG.md
+++ b/gocd/CHANGELOG.md
@@ -1,3 +1,5 @@
+### 2.10.1
+* Switch to a Chainguard bash image for testing (thanks to @chadlwilson)
 ### 2.10.0
 * [aa45b5f](https://github.com/gocd/helm-chart/commit/aa45b5f): Bump up GoCD Version to 24.4.0
 ### 2.9.3

--- a/gocd/Chart.yaml
+++ b/gocd/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: gocd
 home: https://www.gocd.org/
-version: 2.10.0
+version: 2.10.1
 appVersion: 24.4.0
 description: GoCD is an open-source continuous delivery server to model and visualize complex workflows with ease.
 icon: https://gocd.github.io/assets/images/go-icon-black-192x192.png

--- a/gocd/README.md
+++ b/gocd/README.md
@@ -374,15 +374,13 @@ agent:
         subPath: kubectl
   initContainers:
     - name: download-kubectl
-      image: "ghcr.io/containeroo/alpine-toolbox:latest"
+      image: "cgr.dev/chainguard/bash:latest"
       imagePullPolicy: "IfNotPresent"
       volumeMounts:
         - name: kubectl
           mountPath: /download
       workingDir: /download
-      command: ["/bin/bash"]
       args:
-        - "-c"
         - 'curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl && chmod +x ./kubectl'
 u
 ```
@@ -457,12 +455,12 @@ Possible states:
 
 A basic [chart test](https://helm.sh/docs/topics/chart_tests/) is included in this chart. To avoid creating misleading or unused resources in your clusters, the resources required to use `helm test` are not created by default in chart version `1.39.6+` and must be enabled as below.
 
-| Parameter                | Description                                                                                               | Default                                          |
-|--------------------------|-----------------------------------------------------------------------------------------------------------|--------------------------------------------------|
-| `tests.enabled`          | Enable creation of resources to support Helm chart tests with `helm test`.                                | `false`                                          |
-| `tests.batsImage`        | Container image containing [BATS](https://github.com/bats-core/bats-core) binaries, required for testing. | `bats/bats:tag`                                |
-| `tests.curlImage`        | Container image that will run the tests; supplying curl, and able to run BATS.                            | `ghcr.io/containeroo/alpine-toolbox:tag` |
-| `tests.imagePullSecrets` | Image pull secrets for private registries                                                                 | `[]`                                             |
+| Parameter                | Description                                                                                               | Default                           |
+|--------------------------|-----------------------------------------------------------------------------------------------------------|-----------------------------------|
+| `tests.enabled`          | Enable creation of resources to support Helm chart tests with `helm test`.                                | `false`                           |
+| `tests.batsImage`        | Container image containing [BATS](https://github.com/bats-core/bats-core) binaries, required for testing. | `bats/bats:tag`                   |
+| `tests.curlImage`        | Container image that will run the tests; supplying curl, and able to run BATS.                            | `cgr.dev/chainguard/bash:latest`  |
+| `tests.imagePullSecrets` | Image pull secrets for private registries                                                                 | `[]`                              |
 
 # Adding plugins
 

--- a/gocd/values.yaml
+++ b/gocd/values.yaml
@@ -104,15 +104,13 @@ server:
   # specify init containers, e.g. to prepopulate home directories etc
   initContainers: []
   #  - name: download-kubectl
-  #    image: "ellerbrock/alpine-bash-curl-ssl:latest"
+  #    image: "cgr.dev/chainguard/bash:latest"
   #    imagePullPolicy: "IfNotPresent"
   #    volumeMounts:
   #      - name: kubectl
   #        mountPath: /download
   #    workingDir: /download
-  #    command: ["/bin/bash"]
   #    args:
-  #      - "-c"
   #      - 'curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl && chmod +x ./kubectl'
 
   # specify restart policy for server
@@ -383,15 +381,13 @@ agent:
   # specify init containers, e.g. to prepopulate home directories etc
   initContainers: []
   #  - name: download-kubectl
-  #    image: "ellerbrock/alpine-bash-curl-ssl:latest"
+  #    image: "cgr.dev/chainguard/bash:latest"
   #    imagePullPolicy: "IfNotPresent"
   #    volumeMounts:
   #      - name: kubectl
   #        mountPath: /download
   #    workingDir: /download
-  #    command: ["/bin/bash"]
   #    args:
-  #      - "-c"
   #      - 'curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl && chmod +x ./kubectl'
 
   # specify restart policy for agents
@@ -455,8 +451,8 @@ tests:
   enabled: false
   # A BATS image to supply test runner, see https://hub.docker.com/r/bats/bats/tags
   batsImage: "bats/bats:1.11.0"
-  # A image containing bash, curl and busybox|coreutils for executing tests, see https://github.com/containeroo/alpine-toolbox/releases
-  curlImage: "ghcr.io/containeroo/alpine-toolbox:2.4.6"
+  # A image containing bash, curl and busybox|coreutils for executing tests, see https://images.chainguard.dev/directory/image/bash/overview
+  curlImage: "cgr.dev/chainguard/bash:latest"
   # Specify an array of imagePullSecrets to pull from private registries
   # You need to manually create secrets in the namespace
   # See https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/

--- a/gocd/values.yaml
+++ b/gocd/values.yaml
@@ -142,9 +142,9 @@ server:
     #  server.env.extraEnvVars is the list of environment variables passed to GoCD Server
     extraEnvVars:
       - name: GOCD_PLUGIN_INSTALL_kubernetes-elastic-agents
-        value: https://github.com/gocd/kubernetes-elastic-agents/releases/download/v4.1.0-585/kubernetes-elastic-agent-4.1.0-585.jar
+        value: https://github.com/gocd/kubernetes-elastic-agents/releases/download/v4.1.0-606/kubernetes-elastic-agent-4.1.0-606.jar
       - name: GOCD_PLUGIN_INSTALL_docker-registry-artifact-plugin
-        value: https://github.com/gocd/docker-registry-artifact-plugin/releases/download/v1.4.0-773/docker-registry-artifact-plugin-1.4.0-773.jar
+        value: https://github.com/gocd/docker-registry-artifact-plugin/releases/download/v1.4.0-808/docker-registry-artifact-plugin-1.4.0-808.jar
   service:
     # server.service.type is the GoCD Server service type
     type: "NodePort"


### PR DESCRIPTION
Use a more actively maintained community image which is rapidly patched/updated for security vulnerabilities. See https://images.chainguard.dev/directory/image/bash/overview