### PR TITLE
[GoCD Helm Chart] Bump up GoCD Version to 25.1.0

### DIFF
--- a/gocd/CHANGELOG.md
+++ b/gocd/CHANGELOG.md
@@ -1,3 +1,5 @@
+### 2.12.0
+* [f5dfbbb](https://github.com/gocd/helm-chart/commit/f5dfbbb): Bump up GoCD Version to 25.1.0
 ### 2.11.0
 * [667e2e1](https://github.com/gocd/helm-chart/commit/667e2e1): Bump up GoCD Version to 24.5.0
 * Bump pre-installed plugins to latest patched versions (thanks to @chadlwilson)

--- a/gocd/Chart.yaml
+++ b/gocd/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: gocd
 home: https://www.gocd.org/
-version: 2.11.0
-appVersion: 24.5.0
+version: 2.12.0
+appVersion: 25.1.0
 description: GoCD is an open-source continuous delivery server to model and visualize complex workflows with ease.
 icon: https://gocd.github.io/assets/images/go-icon-black-192x192.png
 keywords:


### PR DESCRIPTION
PR to update the helm chart to the latest version of GoCD