### PR TITLE
[GoCD Helm Chart] Bump up GoCD Version to 25.3.0

### DIFF
--- a/gocd/CHANGELOG.md
+++ b/gocd/CHANGELOG.md
@@ -1,3 +1,5 @@
+### 2.15.0
+* [e29dc96](https://github.com/gocd/helm-chart/commit/e29dc96): Bump up GoCD Version to 25.3.0
 ### 2.14.2
 * Bump pre-installed plugins to latest patched versions (thanks to @chadlwilson)
 ### 2.14.1

--- a/gocd/Chart.yaml
+++ b/gocd/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: gocd
 home: https://www.gocd.org/
-version: 2.14.2
-appVersion: 25.2.0
+version: 2.15.0
+appVersion: 25.3.0
 description: GoCD is an open-source continuous delivery server to model and visualize complex workflows with ease.
 icon: https://gocd.github.io/assets/images/go-icon-black-192x192.png
 keywords:
@@ -15,7 +15,7 @@ keywords:
   - continuous-deployment
   - continuous-testing
 sources:
-  - https://github.com/gocd/gocd/tree/25.2.0
+  - https://github.com/gocd/gocd/tree/25.3.0
   - https://github.com/gocd/helm-chart/tree/gocd-2.14.0/gocd
 maintainers:
   - name: chadlwilson
@@ -27,12 +27,12 @@ annotations:
   artifacthub.io/category: integration-delivery
   artifacthub.io/images: |
     - name: gocd-server
-      image: gocd/gocd-server:25.2.0
+      image: gocd/gocd-server:25.3.0
       platforms:
         - linux/amd64
         - linux/arm64
     - name: gocd-agent-wolfi (optional)
-      image: gocd/gocd-agent-wolfi:25.2.0
+      image: gocd/gocd-agent-wolfi:25.3.0
       platforms:
         - linux/amd64
         - linux/arm64


### PR DESCRIPTION
PR to update the helm chart to the latest version of GoCD