### PR TITLE
[GoCD Helm Chart] Bump up GoCD Version to 26.1.0

### DIFF
--- a/gocd/CHANGELOG.md
+++ b/gocd/CHANGELOG.md
@@ -1,3 +1,5 @@
+### 2.18.0
+* [66b3caa](https://github.com/gocd/helm-chart/commit/66b3caa): Bump up GoCD Version to 26.1.0
 ### 2.17.2
 * Bump pre-installed elastic agent plugin to latest patched version (thanks to @chadlwilson)
 ### 2.17.1

--- a/gocd/Chart.yaml
+++ b/gocd/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: gocd
 home: https://www.gocd.org/
-version: 2.17.2
-appVersion: 25.4.0
+version: 2.18.0
+appVersion: 26.1.0
 description: GoCD is an open-source continuous delivery server to model and visualize complex workflows with ease.
 icon: https://gocd.github.io/assets/images/go-icon-black-192x192.png
 keywords:
@@ -15,8 +15,8 @@ keywords:
   - continuous-deployment
   - continuous-testing
 sources:
-  - https://github.com/gocd/gocd/tree/25.4.0
-  - https://github.com/gocd/helm-chart/tree/gocd-2.17.2/gocd
+  - https://github.com/gocd/gocd/tree/26.1.0
+  - https://github.com/gocd/helm-chart/tree/gocd-2.18.0/gocd
 maintainers:
   - name: chadlwilson
     email: chad.lee.wilson@gmail.com
@@ -27,12 +27,12 @@ annotations:
   artifacthub.io/category: integration-delivery
   artifacthub.io/images: |
     - name: gocd-server
-      image: docker.io/gocd/gocd-server:25.4.0
+      image: docker.io/gocd/gocd-server:26.1.0
       platforms:
         - linux/amd64
         - linux/arm64
     - name: gocd-agent-wolfi (optional)
-      image: docker.io/gocd/gocd-agent-wolfi:25.4.0
+      image: docker.io/gocd/gocd-agent-wolfi:26.1.0
       platforms:
         - linux/amd64
         - linux/arm64


### PR DESCRIPTION
PR to update the helm chart to the latest version of GoCD